### PR TITLE
Add missing architecture image to README

### DIFF
--- a/assets/arch.png
+++ b/assets/arch.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66d915c58905251f2c6e3707f39a7d6a8c473e6922070866847fbeb9efad5888
+size 499628


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Now README shows the architecture of the Open Interfaces