### PR TITLE
Add GitHub Actions status badge to README

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,5 +1,5 @@
 ---
-name: QA conda
+name: QA
 
 on:
     push:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![QA](https://github.com/MaRDI4NFDI/open-interfaces/actions/workflows/qa.yaml/badge.svg)](https://github.com/MaRDI4NFDI/open-interfaces/actions/workflows/qa.yaml)
+
 # MaRDI Open Interfaces
 
 _MaRDI Open Interfaces_ is a project aiming to improve interoperability


### PR DESCRIPTION
**Changes**:
- Add GitHub Actions status badge to README
- Rename GitHub workflow from "QA conda" to "QA"
