### PR TITLE
Fix outdated code

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # Set project root directory to use absolute paths below.
-export PRJ_ROOT_DIR="$PWD"
+export PRJ_ROOT_DIR="$(dirname $(realpath "$0"))"
 
 # Set path to implementations
 export OIF_IMPL_ROOT_DIR="${PRJ_ROOT_DIR}"

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,9 @@
 # Set project root directory to use absolute paths below.
-export PRJ_ROOT_DIR="$(dirname $(realpath "$0"))"
+if [ "$GITHUB_ACTIONS" = "true" ]; then
+    export PRJ_ROOT_DIR="$GITHUB_WORKSPACE"
+else
+    export PRJ_ROOT_DIR="$(dirname $(realpath "$0"))"
+fi
 
 # Set path to implementations
 export OIF_IMPL_ROOT_DIR="${PRJ_ROOT_DIR}"

--- a/examples/call_ivp_from_c_burgers_eq.c
+++ b/examples/call_ivp_from_c_burgers_eq.c
@@ -195,15 +195,14 @@ main(int argc, char *argv[])
         status = oif_ivp_set_integrator(implh, "DP5", NULL);
     }
     assert(status == 0);
-
-    int n_rhs_evals = 42;
+    double t = 0.0001;
+    status = oif_ivp_integrate(implh, t, y);
 
     clock_t tic = clock();
     // Time step.
     double dt = dt_max;
     int n_time_steps = (int)(t_final / dt + 1);
     for (int i = 0; i < n_time_steps; ++i) {
-        n_rhs_evals = 42;
         double t = t0 + (i + 1) * dt;
         if (t > t_final) {
             t = t_final;
@@ -214,9 +213,6 @@ main(int argc, char *argv[])
             retval = EXIT_FAILURE;
             goto cleanup;
         }
-        status = oif_ivp_get_n_rhs_evals(implh, &n_rhs_evals);
-        assert(status == 0);
-        printf("t = %.3f, n_rhs_evals = %d\n", t, n_rhs_evals);
     }
     clock_t toc = clock();
     printf("Elapsed time = %.6f seconds\n", (double)(toc - tic) / CLOCKS_PER_SEC);

--- a/examples/call_ivp_from_c_burgers_eq.c
+++ b/examples/call_ivp_from_c_burgers_eq.c
@@ -193,6 +193,9 @@ main(int argc, char *argv[])
         goto cleanup;
     }
 
+    status = oif_ivp_set_tolerances(implh, 1e-8, 1e-12);
+    assert(status == 0);
+
     if (strcmp(impl, "scipy_ode") == 0) {
         status = oif_ivp_set_integrator(implh, "dopri5", NULL);
     }

--- a/examples/call_ivp_from_c_burgers_eq.c
+++ b/examples/call_ivp_from_c_burgers_eq.c
@@ -53,6 +53,17 @@ parse_output_filename(int argc, char *argv[])
     }
 }
 
+int
+parse_resolution(int argc, char *argv[])
+{
+    if (argc < 3) {
+        return 101;
+    }
+    else {
+        return atoi(argv[3]);
+    }
+}
+
 static int
 compute_initial_condition_(size_t N, OIFArrayF64 *u0, OIFArrayF64 *grid, double *dx,
                            double *dt_max)
@@ -152,7 +163,7 @@ main(int argc, char *argv[])
     printf("Implementation: %s\n", impl);
 
     int retval = 0;
-    int N = 101;
+    const int N = parse_resolution(argc, argv);
     double t0 = 0.0;
     double t_final = 2.0;
     OIFArrayF64 *y0 = oif_create_array_f64(1, (intptr_t[1]){N});

--- a/examples/call_ivp_from_c_burgers_eq.c
+++ b/examples/call_ivp_from_c_burgers_eq.c
@@ -207,11 +207,16 @@ main(int argc, char *argv[])
     status = oif_ivp_set_tolerances(implh, 1e-8, 1e-12);
     assert(status == 0);
 
+    OIFConfigDict *dict = oif_config_dict_init();
+    oif_config_dict_add_int(dict, "dense", 0);
+    oif_config_dict_add_int(dict, "save_everystep", 0);
+
     if (strcmp(impl, "scipy_ode") == 0) {
         status = oif_ivp_set_integrator(implh, "dopri5", NULL);
     }
     else if (strcmp(impl, "jl_diffeq") == 0) {
         status = oif_ivp_set_integrator(implh, "DP5", NULL);
+        /* status = oif_ivp_set_integrator(implh, "DP5", dict); */
     }
     assert(status == 0);
     double t = 0.0001;

--- a/examples/call_ivp_from_c_burgers_eq.c
+++ b/examples/call_ivp_from_c_burgers_eq.c
@@ -21,6 +21,9 @@
 #include <oif/c_bindings.h>
 #include <oif/interfaces/ivp.h>
 
+// Number of right-hand side evaluations.
+static int N_RHS_EVALS = 0;
+
 char *
 parse_impl(int argc, char *argv[])
 {
@@ -126,6 +129,8 @@ rhs(double t, OIFArrayF64 *y, OIFArrayF64 *rhs_out, void *user_data)
 
     retval = 0;
 
+    N_RHS_EVALS++;
+
 cleanup:
     if (flux != NULL) {
         free(flux);
@@ -216,6 +221,7 @@ main(int argc, char *argv[])
     }
     clock_t toc = clock();
     printf("Elapsed time = %.6f seconds\n", (double)(toc - tic) / CLOCKS_PER_SEC);
+    printf("Number of right-hand side evaluations = %d\n", N_RHS_EVALS);
 
     FILE *fp = fopen(output_filename, "w+e");
     if (fp == NULL) {

--- a/examples/call_ivp_from_python_burgers_eq.py
+++ b/examples/call_ivp_from_python_burgers_eq.py
@@ -55,7 +55,7 @@ class BurgersEquationProblem:
     def compute_rhs(self, __, u: np.ndarray, udot: np.ndarray, ___) -> None:
         dx = self.dx
 
-        f = 0.5 * u ** 2
+        f = 0.5 * u**2
         local_ss = np.maximum(np.abs(u[0:-1]), np.abs(u[1:]))
         local_ss = np.max(np.abs(u))
         f_hat = 0.5 * (f[0:-1] + f[1:]) - 0.5 * local_ss * (u[1:] - u[0:-1])

--- a/examples/call_ivp_from_python_burgers_eq.py
+++ b/examples/call_ivp_from_python_burgers_eq.py
@@ -16,8 +16,8 @@ def _parse_args():
     p = argparse.ArgumentParser()
     p.add_argument(
         "impl",
-        choices=["scipy_ode_dopri5", "sundials_cvode"],
-        default="scipy_ode_dopri5",
+        choices=["scipy_ode", "sundials_cvode"],
+        default="scipy_ode",
         nargs="?",
     )
     args = p.parse_args()
@@ -52,10 +52,10 @@ class BurgersEquationProblem:
         self.t0 = 0.0
         self.tfinal = 2.0
 
-    def compute_rhs(self, __, u: np.ndarray, udot: np.ndarray) -> None:
+    def compute_rhs(self, __, u: np.ndarray, udot: np.ndarray, ___) -> None:
         dx = self.dx
 
-        f = 0.5 * u**2
+        f = 0.5 * u ** 2
         local_ss = np.maximum(np.abs(u[0:-1]), np.abs(u[1:]))
         local_ss = np.max(np.abs(u))
         f_hat = 0.5 * (f[0:-1] + f[1:]) - 0.5 * local_ss * (u[1:] - u[0:-1])
@@ -94,6 +94,7 @@ def main():
     plt.plot(problem.x, soln[0], "--", label="Initial condition")
     plt.plot(problem.x, soln[-1], "-", label="Final solution")
     plt.legend(loc="best")
+    plt.tight_layout(pad=0.1)
     plt.savefig(os.path.join("assets", f"ivp_burgers_soln_{impl}.pdf"))
     print("Finished")
 

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -104,9 +104,10 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
     strcat(conf_filename, impl);
     strcat(conf_filename, ".conf");
 
-    conf_file = fopen(conf_filename, "re");
+    conf_file = fopen(conf_filename, "r");
     if (conf_file == NULL) {
-        fprintf(stderr, "[dispatch] Cannot load conf file '%s'\n", conf_filename);
+        fprintf(stderr, "[dispatch] Cannot open conf file '%s'\n", conf_filename);
+        perror("Error message is: ");
         return -1;
     }
     else {

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -28,6 +28,14 @@ int
 oif_ivp_set_user_data(ImplHandle implh, void *user_data);
 
 /**
+ * Set tolerances for adaptive time integration.
+ * @param rtol Relative tolerance
+ * @param atol Absolute tolerance
+ */
+int
+oif_ivp_set_tolerances(ImplHandle implh, double rtol, double atol);
+
+/**
  * Integrate to time `t` and write the solution to `y`.
  */
 int

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -39,6 +39,12 @@ oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y);
 int
 oif_ivp_set_integrator(ImplHandle implh, char *integrator_name, OIFConfigDict *config);
 
+/**
+ * Get the number of function evaluations during the last call to `oif_ivp_integrate`.
+ */
+int
+oif_ivp_get_n_rhs_evals(ImplHandle implh, int *n_rhs_evals);
+
 #ifdef __cplusplus
 }
 #endif

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -84,6 +84,30 @@ oif_ivp_set_user_data(ImplHandle implh, void *user_data)
 }
 
 int
+oif_ivp_set_tolerances(ImplHandle implh, double rtol, double atol)
+{
+    OIFArgType in_arg_types[] = {OIF_FLOAT64, OIF_FLOAT64};
+    void *in_arg_values[] = {&rtol, &atol};
+    OIFArgs in_args = {
+        .num_args = 2,
+        .arg_types = in_arg_types,
+        .arg_values = in_arg_values,
+    };
+
+    OIFArgType out_arg_types[] = {};
+    void *out_arg_values[] = {};
+    OIFArgs out_args = {
+        .num_args = 0,
+        .arg_types = out_arg_types,
+        .arg_values = out_arg_values,
+    };
+
+    int status = call_interface_impl(implh, "set_tolerances", &in_args, &out_args);
+
+    return status;
+}
+
+int
 oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y)
 {
     OIFArgType in_arg_types[] = {OIF_FLOAT64};

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -108,6 +108,30 @@ oif_ivp_integrate(ImplHandle implh, double t, OIFArrayF64 *y)
 }
 
 int
+oif_ivp_get_n_rhs_evals(ImplHandle implh, int *n_rhs_evals)
+{
+    OIFArgType in_arg_types[] = {};
+    void *in_arg_values[] = {};
+    OIFArgs in_args = {
+        .num_args = 0,
+        .arg_types = in_arg_types,
+        .arg_values = in_arg_values,
+    };
+
+    OIFArgType out_arg_types[] = {OIF_INT};
+    void *out_arg_values[] = {&n_rhs_evals};
+    OIFArgs out_args = {
+        .num_args = 1,
+        .arg_types = out_arg_types,
+        .arg_values = out_arg_values,
+    };
+
+    int status = call_interface_impl(implh, "get_n_rhs_evals", &in_args, &out_args);
+
+    return status;
+}
+
+int
 oif_ivp_set_integrator(ImplHandle implh, char *integrator_name, OIFConfigDict *dict)
 {
     if (dict != NULL) {

--- a/oif_impl/impl/ivp/scipy_ode/scipy_ode.py
+++ b/oif_impl/impl/ivp/scipy_ode/scipy_ode.py
@@ -59,6 +59,10 @@ class ScipyODE(IVPInterface):
         assert self.s.successful()
         return 0
 
+    def get_n_rhs_evals(self, n_rhs_evals_arr):
+        n_rhs_evals_arr[0] = self.s._integrator.iwork[16]
+        return 0
+
     def set_integrator(self, integrator_name, integrator_params):
         if self.s is None:
             raise RuntimeError("`set_integrator` must be called after `set_rhs_fn`")

--- a/oif_impl/impl/ivp/scipy_ode/scipy_ode.py
+++ b/oif_impl/impl/ivp/scipy_ode/scipy_ode.py
@@ -44,7 +44,7 @@ class ScipyODE(IVPInterface):
     def set_tolerances(self, rtol, atol):
         if self.s is None:
             raise RuntimeError("`set_rhs_fn` must be called before `set_tolerances`")
-        self.s.set_integrator(self.integrator, rtol=rtol, atol=atol, nsteps=1000)
+        self.s.set_integrator(self.integrator, rtol=rtol, atol=atol)
         self.rtol = rtol
         self.atol = atol
         if hasattr(self, "y0"):

--- a/oif_impl/lang_python/dispatch_python.c
+++ b/oif_impl/lang_python/dispatch_python.c
@@ -386,7 +386,9 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         // Convert output arguments.
         for (size_t i = 0; i < out_args->num_args; ++i) {
             if (out_args->arg_types[i] == OIF_INT) {
-                pValue = PyLong_FromLong(*(int *)out_args->arg_values[i]);
+                int *tmp = *(int **)out_args->arg_values[i];
+                printf("tmp =====  %d\n", *tmp);
+                pValue = PyArray_SimpleNewFromData(1, (intptr_t[1]){1}, NPY_INT32, tmp);
             }
             else if (out_args->arg_types[i] == OIF_FLOAT64) {
                 pValue = PyFloat_FromDouble(*(double *)out_args->arg_values[i]);


### PR DESCRIPTION
This PR fixes a couple of things:

- Add `ivp::set_tolerances` method to the C interface
- Update Burgers' example in C by comparing SciPy's `dopri5` with OrdinaryDiffEq.jl's `DP5` for fair comparison
- Fixes outdated implementation names in the Burgers' example in Python
