### PR TITLE
[IVP] Disable dense output in `jl_diffeq` to improve performance

### DIFF
--- a/oif_impl/impl/ivp/jl_diffeq/jl_diffeq.jl
+++ b/oif_impl/impl/ivp/jl_diffeq/jl_diffeq.jl
@@ -85,6 +85,6 @@ function _init(self::Self)
             _rhs_wrapper(self.rhs), self.y0, (self.t0, Inf), self.user_data
         )
     end
-    self.solver = init(problem, self.integrator, reltol = self.reltol, abstol = self.abstol)
+    self.solver = init(problem, self.integrator, reltol = self.reltol, abstol = self.abstol, save_everystep = false)
 end
 end


### PR DESCRIPTION
This PR disable dense output in the `jl_diffeq` `IVP` implementation, so that the performance could be more fairly compared to other implementations.
Also, as we use `step!` function to manually timestep, the dense output is not available to the user anyway, so the intermediate solutions are saved for nothing.
 
