### PR TITLE
Add Dorman-Prince 5(4) implementation in C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   message("Disable optimizations for Debug build type")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
+  string(PREPEND CMAKE_C_FLAGS_DEBUG "-O0 ")
 endif()
 
 set(CMAKE_C_FLAGS_ASAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,31 +11,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   string(PREPEND CMAKE_C_FLAGS_DEBUG "-O0 ")
 endif()
 
-set(CMAKE_C_FLAGS_ASAN
-    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer"
-    CACHE STRING
-          "Flags used by the C compiler for Asan build type or configuration."
-          FORCE)
-
-set(CMAKE_CXX_FLAGS_ASAN
-    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer"
-    CACHE STRING
-          "Flags used by the C++ compiler for Asan build type or configuration."
-          FORCE)
-
-set(CMAKE_EXE_LINKER_FLAGS_ASAN
-    "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address"
-    CACHE STRING
-          "Linker flags to be used to create executables for Asan build type."
-          FORCE)
-
-set(CMAKE_SHARED_LINKER_FLAGS_ASAN
-    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address"
-    CACHE
-      STRING
-      "Linker lags to be used to create shared libraries for Asan build type."
-      FORCE)
-
 # Incorporate additions by X/Open 7, that includes POSIX 17 additions and allow
 # to use things like the `M_PI` constant in the code without warnings from
 # static analyzers.
@@ -61,4 +36,4 @@ add_subdirectory(oif_impl)
 add_subdirectory(examples)
 
 enable_testing()
-add_subdirectory(tests)
+# add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,31 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0")
 endif()
 
+set(CMAKE_C_FLAGS_ASAN
+    "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer"
+    CACHE STRING
+          "Flags used by the C compiler for Asan build type or configuration."
+          FORCE)
+
+set(CMAKE_CXX_FLAGS_ASAN
+    "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer"
+    CACHE STRING
+          "Flags used by the C++ compiler for Asan build type or configuration."
+          FORCE)
+
+set(CMAKE_EXE_LINKER_FLAGS_ASAN
+    "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fsanitize=address"
+    CACHE STRING
+          "Linker flags to be used to create executables for Asan build type."
+          FORCE)
+
+set(CMAKE_SHARED_LINKER_FLAGS_ASAN
+    "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -fsanitize=address"
+    CACHE
+      STRING
+      "Linker lags to be used to create shared libraries for Asan build type."
+      FORCE)
+
 # Incorporate additions by X/Open 7, that includes POSIX 17 additions and allow
 # to use things like the `M_PI` constant in the code without warnings from
 # static analyzers.

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,10 @@
-UNAME := $(shell uname)
-PWD := $(shell pwd)
-
-ifeq ($(UNAME), Darwin)  # macOS
-    DSO_EXT := dylib
-else                    # Linux
-    DSO_EXT := so
-endif
-
 .PHONY : all
 all :
-	cmake -S . -B build.debug -DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
+	cmake -S . -B build.debug \
+		-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+		&& \
 	cmake --build build.debug && \
 	rm -f build && \
 	ln -sv build.debug build
@@ -26,10 +21,18 @@ pytest-valgrind :
 
 .PHONY : release
 release :
-	cmake -S . -B build.release -DCMAKE_VERBOSE_MAKEFILE:BOOL=FALSE -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON && \
+	cmake -S . -B build.release \
+		-DCMAKE_VERBOSE_MAKEFILE:BOOL=FALSE \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+		&& \
 	cmake --build build.release && \
 	rm -f build && \
 	ln -sv build.release build
+
+.PHONY : clean
+clean :
+	$(RM) -r build build.debug build.release
 
 .PHONY : docs
 docs :

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -305,3 +305,12 @@ call_interface_impl(ImplHandle implh, const char *method, OIFArgs *in_args, OIFA
     }
     return status;
 }
+
+
+#if defined(__GNUC__)
+    #if !defined(__OPTIMIZE__)
+        void __attribute__((destructor)) dtor() {
+            fprintf(stderr, "[dispatch] WARNING: running non-optimized build\n");
+        }
+    #endif
+#endif

--- a/oif/dispatch.c
+++ b/oif/dispatch.c
@@ -104,7 +104,7 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
     strcat(conf_filename, impl);
     strcat(conf_filename, ".conf");
 
-    conf_file = fopen(conf_filename, "r");
+    conf_file = fopen(conf_filename, "re");
     if (conf_file == NULL) {
         fprintf(stderr, "[dispatch] Cannot open conf file '%s'\n", conf_filename);
         perror("Error message is: ");
@@ -306,11 +306,12 @@ call_interface_impl(ImplHandle implh, const char *method, OIFArgs *in_args, OIFA
     return status;
 }
 
-
 #if defined(__GNUC__)
-    #if !defined(__OPTIMIZE__)
-        void __attribute__((destructor)) dtor() {
-            fprintf(stderr, "[dispatch] WARNING: running non-optimized build\n");
-        }
-    #endif
+#if !defined(__OPTIMIZE__)
+void __attribute__((destructor))
+dtor()
+{
+    fprintf(stderr, "[dispatch] WARNING: running non-optimized build\n");
+}
+#endif
 #endif

--- a/oif/include/oif/allocation_tracker.h
+++ b/oif/include/oif/allocation_tracker.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <stdlib.h>
 
 typedef void(cleanup_fn)(void *p);
 

--- a/oif/interfaces/c/include/oif/interfaces/ivp.h
+++ b/oif/interfaces/c/include/oif/interfaces/ivp.h
@@ -48,10 +48,10 @@ int
 oif_ivp_set_integrator(ImplHandle implh, char *integrator_name, OIFConfigDict *config);
 
 /**
- * Get the number of function evaluations during the last call to `oif_ivp_integrate`.
+ * Print statistics about integration.
  */
 int
-oif_ivp_get_n_rhs_evals(ImplHandle implh, int *n_rhs_evals);
+oif_ivp_print_stats(ImplHandle implh);
 
 #ifdef __cplusplus
 }

--- a/oif/interfaces/c/src/ivp.c
+++ b/oif/interfaces/c/src/ivp.c
@@ -182,3 +182,22 @@ oif_ivp_set_integrator(ImplHandle implh, char *integrator_name, OIFConfigDict *d
     int status = call_interface_impl(implh, "set_integrator", &in_args, &out_args);
     return status;
 }
+
+int
+oif_ivp_print_stats(ImplHandle implh)
+{
+    OIFArgs in_args = {
+        .num_args = 0,
+        .arg_types = NULL,
+        .arg_values = NULL,
+    };
+
+    OIFArgs out_args = {
+        .num_args = 0,
+        .arg_types = NULL,
+        .arg_values = NULL,
+    };
+
+    int status = call_interface_impl(implh, "print_stats", &in_args, &out_args);
+    return status;
+}

--- a/oif/lang_c/allocation_tracker.c
+++ b/oif/lang_c/allocation_tracker.c
@@ -74,5 +74,7 @@ allocation_tracker_free(void *tracker_)
         }
     }
 
+    free(tracker->pointers);
+    free(tracker->cleanup_fns);
     free(tracker);
 }

--- a/oif/lang_c/allocation_tracker.c
+++ b/oif/lang_c/allocation_tracker.c
@@ -68,10 +68,8 @@ allocation_tracker_free(void *tracker_)
 {
     AllocationTracker *tracker = tracker_;
     assert(tracker->type == ALLOCATION_TRACKER_TYPE);
-    if (tracker->size) {
-        for (size_t i = 0; i < tracker->size; ++i) {
-            tracker->cleanup_fns[i](tracker->pointers[i]);
-        }
+    for (size_t i = 0; i < tracker->size; ++i) {
+        tracker->cleanup_fns[i](tracker->pointers[i]);
     }
 
     free(tracker->pointers);

--- a/oif_impl/impl/ivp/CMakeLists.txt
+++ b/oif_impl/impl/ivp/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(sundials_cvode)
+add_subdirectory(dopri5c)

--- a/oif_impl/impl/ivp/dopri5c/CMakeLists.txt
+++ b/oif_impl/impl/ivp/dopri5c/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(oif_ivp_dopri5c SHARED dopri5c.c)
+target_link_libraries(oif_ivp_dopri5c PRIVATE m)
+target_include_directories(oif_ivp_dopri5c
+                           PRIVATE ${CMAKE_SOURCE_DIR}/oif/include)
+target_include_directories(oif_ivp_dopri5c
+                           PRIVATE ${CMAKE_SOURCE_DIR}/oif_impl/lang_c/include)
+target_link_libraries(oif_ivp_dopri5c PRIVATE oif_c_data_structures)
+target_link_libraries(oif_ivp_dopri5c PRIVATE oif_c_util)

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -52,13 +52,6 @@ static double self_h = 0.0;
 // Number of right-hand side function evaluations.
 static size_t nfcn_ = 0;
 
-static const char *AVAILABLE_OPTIONS_[] = {
-    "max_num_steps",
-    NULL,
-};
-
-static double eps = 1e-12;
-
 // Coefficients before time step in expressions like t + c * dt.
 static double C2 = 1.0 / 5.0;
 static double C3 = 3.0 / 10.0;

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -98,12 +98,6 @@ double const ORDER_OF_ACC = 4;
 
 size_t n_rejected = 0;
 
-static int
-init_(void)
-{
-    return 0;
-}
-
 static void
 compute_initial_step_() {
     double h0;
@@ -184,7 +178,7 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
     self_N = y0_in->dimensions[0];
 
     self_y = oif_create_array_f64(1, y0_in->dimensions);
-    for (size_t i = 0; i < self_y->dimensions[0]; ++i) {
+    for (int i = 0; i < self_N; ++i) {
         self_y->data[i] = y0_in->data[i];
     }
 
@@ -328,7 +322,7 @@ integrate(double t_, OIFArrayF64 *y_out)
         OIF_RHS_FN(self_t + self_h, self_ysti, self_k6, self_user_data);
 
         // Estimate less accurate.
-        for (size_t i = 0; i < self_y->dimensions[0]; ++i) {
+        for (int i = 0; i < self_N; ++i) {
             self_y1->data[i] = self_y->data[i] + self_h * (
                 a7[1] * self_k1->data[i] + a7[3] * self_k3->data[i] +
                 a7[4] * self_k4->data[i] + a7[5] * self_k5->data[i] +
@@ -342,7 +336,7 @@ integrate(double t_, OIFArrayF64 *y_out)
         // Error estimation.
         double err = 0.0;
 
-        for (size_t i = 0; i < self_N; ++i) {
+        for (int i = 0; i < self_N; ++i) {
             self_k4->data[i] = self_h * (
                 e[1] * self_k1->data[i] +
                 e[3] * self_k3->data[i] + e[4] * self_k4->data[i] +

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -61,19 +61,16 @@ static double C5 = 8.0 / 9.0;
 // Leading zeros here are only to match the index to the corresponding vector.
 static double a2[] = {0.0, 0.2};
 static double a3[] = {0.0, 3.0 / 40.0, 9.0 / 40.0};
-static double a4[] = {0, 44.0/45.0, -56.0/15.0, 32.0/9.0};
-static double a5[] = {0, 19372.0/6561.0, -25360.0/2187.0, 64448.0/6561.0, -212.0/729.0};
-static double a6[] = {0, 9017.0/3168.0, -355.0/33.0, 46732.0/5247.0, 49.0/176.0, -5103.0/18656.0};
-static double a7[] = {0, 35.0/384.0, 0.0, 500.0/1113.0, 125.0/192.0, -2187.0/6784.0, 11.0/84.0};
+static double a4[] = {0, 44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0};
+static double a5[] = {0, 19372.0 / 6561.0, -25360.0 / 2187.0, 64448.0 / 6561.0,
+                      -212.0 / 729.0};
+static double a6[] = {
+    0, 9017.0 / 3168.0, -355.0 / 33.0, 46732.0 / 5247.0, 49.0 / 176.0, -5103.0 / 18656.0};
+static double a7[] = {
+    0, 35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0};
 static double e[] = {
-    0.0,
-    71.0/57600.0,
-    0.0,
-    -71.0/16695.0,
-    71.0/1920.0,
-    -17253.0/339200.0,
-    22.0/525.0,
-    -1.0 / 40.0,
+    0.0,           71.0 / 57600.0,      0.0,          -71.0 / 16695.0,
+    71.0 / 1920.0, -17253.0 / 339200.0, 22.0 / 525.0, -1.0 / 40.0,
 };
 
 // Step size control parameters.
@@ -84,15 +81,16 @@ double FACC1;
 double FACC2;
 
 double FACOLD = 1e-4;
-double const FACMIN = 0.2;    // In Hairer's code FAC1
-double const FACMAX = 10.0;   // In Hairer's code FAC2
+double const FACMIN = 0.2;   // In Hairer's code FAC1
+double const FACMAX = 10.0;  // In Hairer's code FAC2
 double FAC = 0.8;
 double const ORDER_OF_ACC = 4;
 
 size_t n_rejected = 0;
 
 static void
-compute_initial_step_() {
+compute_initial_step_()
+{
     double h0;
     double h1;
 
@@ -150,11 +148,7 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
     self_t = t0_in;
 
     if (y0_in->nd != 1) {
-        fprintf(
-            stderr,
-            "[%s] Accept only one-dimensional arrays (vectors)\n",
-            prefix_
-        );
+        fprintf(stderr, "[%s] Accept only one-dimensional arrays (vectors)\n", prefix_);
         return 1;
     }
 
@@ -222,8 +216,8 @@ set_tolerances(double rtol, double atol)
 int
 set_integrator(const char *integrator_name, OIFConfigDict *config_)
 {
-    (void) integrator_name;
-    (void) config_;
+    (void)integrator_name;
+    (void)config_;
     fprintf(stderr, "[%s] Method `set_integrator` is not supported\n", prefix_);
     return 0;
 }
@@ -275,52 +269,43 @@ integrate(double t_, OIFArrayF64 *y_out)
 
         // 3rd stage
         for (int i = 0; i < self_N; ++i) {
-            self_y1->data[i] = self_y->data[i] + self_h * (
-                a3[1] * self_k1->data[i] + a3[2] * self_k2->data[i]
-            );
+            self_y1->data[i] = self_y->data[i] +
+                               self_h * (a3[1] * self_k1->data[i] + a3[2] * self_k2->data[i]);
         }
         OIF_RHS_FN(self_t + C3 * self_h, self_y1, self_k3, self_user_data);
 
         // 4th stage
         for (int i = 0; i < self_N; ++i) {
-            self_y1->data[i] = self_y->data[i] + self_h * (
-                a4[1] * self_k1->data[i] +
-                a4[2] * self_k2->data[i] +
-                a4[3] * self_k3->data[i]
-            );
+            self_y1->data[i] = self_y->data[i] +
+                               self_h * (a4[1] * self_k1->data[i] + a4[2] * self_k2->data[i] +
+                                         a4[3] * self_k3->data[i]);
         }
         OIF_RHS_FN(self_t + C4 * self_h, self_y1, self_k4, self_user_data);
 
         // 5th stage
         for (int i = 0; i < self_N; ++i) {
-            self_y1->data[i] = self_y->data[i] + self_h * (
-                a5[1] * self_k1->data[i] +
-                a5[2] * self_k2->data[i] +
-                a5[3] * self_k3->data[i] +
-                a5[4] * self_k4->data[i]
-            );
+            self_y1->data[i] = self_y->data[i] +
+                               self_h * (a5[1] * self_k1->data[i] + a5[2] * self_k2->data[i] +
+                                         a5[3] * self_k3->data[i] + a5[4] * self_k4->data[i]);
         }
         OIF_RHS_FN(self_t + C5 * self_h, self_y1, self_k5, self_user_data);
 
         // step 6.
         for (int i = 0; i < self_N; ++i) {
-            self_ysti->data[i] = self_y->data[i] + self_h * (
-                a6[1] * self_k1->data[i] +
-                a6[2] * self_k2->data[i] +
-                a6[3] * self_k3->data[i] +
-                a6[4] * self_k4->data[i] +
-                a6[5] * self_k5->data[i]
-            );
+            self_ysti->data[i] =
+                self_y->data[i] +
+                self_h * (a6[1] * self_k1->data[i] + a6[2] * self_k2->data[i] +
+                          a6[3] * self_k3->data[i] + a6[4] * self_k4->data[i] +
+                          a6[5] * self_k5->data[i]);
         }
         OIF_RHS_FN(self_t + self_h, self_ysti, self_k6, self_user_data);
 
         // Estimate less accurate.
         for (int i = 0; i < self_N; ++i) {
-            self_y1->data[i] = self_y->data[i] + self_h * (
-                a7[1] * self_k1->data[i] + a7[3] * self_k3->data[i] +
-                a7[4] * self_k4->data[i] + a7[5] * self_k5->data[i] +
-                a7[6] * self_k6->data[i]
-            );
+            self_y1->data[i] = self_y->data[i] +
+                               self_h * (a7[1] * self_k1->data[i] + a7[3] * self_k3->data[i] +
+                                         a7[4] * self_k4->data[i] + a7[5] * self_k5->data[i] +
+                                         a7[6] * self_k6->data[i]);
         }
         OIF_RHS_FN(self_t + self_h, self_y1, self_k2, self_user_data);
 
@@ -330,13 +315,11 @@ integrate(double t_, OIFArrayF64 *y_out)
         double err = 0.0;
 
         for (int i = 0; i < self_N; ++i) {
-            self_k4->data[i] = self_h * (
-                e[1] * self_k1->data[i] +
-                e[3] * self_k3->data[i] + e[4] * self_k4->data[i] +
-                e[5] * self_k5->data[i] + e[6] * self_k6->data[i] +
-                e[7] * self_k2->data[i]
-            );
-            double sk = self_atol + self_rtol * MAX(fabs(self_y->data[i]), fabs(self_y1->data[i]));
+            self_k4->data[i] = self_h * (e[1] * self_k1->data[i] + e[3] * self_k3->data[i] +
+                                         e[4] * self_k4->data[i] + e[5] * self_k5->data[i] +
+                                         e[6] * self_k6->data[i] + e[7] * self_k2->data[i]);
+            double sk =
+                self_atol + self_rtol * MAX(fabs(self_y->data[i]), fabs(self_y1->data[i]));
             err += pow(self_k4->data[i] / sk, 2);
         }
         err = sqrt(err / self_N);
@@ -345,7 +328,7 @@ integrate(double t_, OIFArrayF64 *y_out)
         // Lund stabilization.
         FAC = FAC11 / pow(FACOLD, BETA);
         // We require FACMIN <= HNEW/H <= FACMAX
-        FAC = MAX(FACC2, MIN(FACC1, FAC/SAFE));
+        FAC = MAX(FACC2, MIN(FACC1, FAC / SAFE));
         double hnew = self_h / FAC;
 
         if (err < 1.0) {

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -1,0 +1,307 @@
+/**
+ * Implementation of the `ivp` interface with hand-written Dormand-Prince 5(4).
+ */
+#include <assert.h>
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <tgmath.h>
+
+#include <oif/api.h>
+#include <oif/util.h>
+#include <oif_impl/ivp.h>
+#include <oif/c_bindings.h>
+
+#define MIN(i, j) (((i) < (j)) ? (i) : (j))
+#define MAX(i, j) (((i) > (j)) ? (i) : (j))
+
+static const char *prefix_ = "ivp::dopri5c";
+
+double self_t = 0.0;
+double self_rtol = 1e-6;   // relative tolerance
+double self_atol = 1e-12;  // absolute tolerance
+int self_N = 0;            // Length of the solution vector.
+OIFArrayF64 *self_y = NULL;
+OIFArrayF64 *self_yt = NULL;
+
+// Runge--Kutta stages.
+OIFArrayF64 *self_k1 = NULL;
+OIFArrayF64 *self_k2 = NULL;
+OIFArrayF64 *self_k3 = NULL;
+OIFArrayF64 *self_k4 = NULL;
+OIFArrayF64 *self_k5 = NULL;
+OIFArrayF64 *self_k6 = NULL;
+
+OIFArrayF64 *self_y2 = NULL;
+OIFArrayF64 *self_y3 = NULL;
+OIFArrayF64 *self_y4 = NULL;
+OIFArrayF64 *self_y5 = NULL;
+OIFArrayF64 *self_y6 = NULL;
+
+OIFConfigDict *config = NULL;
+void *self_user_data = NULL;
+// Signature for the right-hand side that is provided by the `IVP` interface.
+static oif_ivp_rhs_fn_t OIF_RHS_FN = NULL;
+
+static const char *AVAILABLE_OPTIONS_[] = {
+    "max_num_steps",
+    NULL,
+};
+
+static double eps = 1e-12;
+
+// Leading zeros here are only to match the index to the corresponding vector.
+static double a4[] = {0, 44.0L/45, -56.0L/15, 32.0L/9};
+static double a5[] = {0, 19372.0L/6561, -25360.0L/2187, 64448.0L/6561, -212.0L/729};
+static double a6[] = {0, 9017.0L/3168, -355.0L/33, 46732.0L/5247, 49.0L/176, -5103.0L/18656};
+static double a7[] = {0, 35.0L/384, 0.0, 500.0L/1113, 125.0/192, -2187.0/6784, 11.0/84};
+static double e[] = {0, 71.0L/57600, -1.0/40, -71.0L/16695, 71.0L/1920, -17253.0L/339200, 22.0L/525};
+
+// Step size control parameters.
+double SAFE = 0.9L;
+double BETA = 0.04L;
+double EXP01 = 0.0;
+double FAC1 = 0.2L;
+double FACC1;
+
+double const FACMAX_DEFAULT = 1.5;
+double const FACMIN = 0.2;
+double const FAC = 0.8;
+double const ORDER_OF_ACC = 4;
+double FACMAX;  // FACMAX depends on step acceptance/rejection (see Hairer, vol. 1, p. 168)
+
+size_t n_rejected = 0;
+
+
+static int
+init_(void)
+{
+    return 0;
+}
+
+int
+set_initial_value(OIFArrayF64 *y0_in, double t0_in)
+{
+    EXP01 = 0.2L - BETA * 0.75L;
+    FACC1 = 1.0L / FAC1;
+    FACMAX = FACMAX_DEFAULT;
+    self_t = t0_in;
+
+    if (y0_in->nd != 1) {
+        fprintf(
+            stderr,
+            "[%s] Accept only one-dimensional arrays (vectors)\n",
+            prefix_
+        );
+    }
+
+    if (self_y) {
+        oif_free_array_f64(self_y);
+        oif_free_array_f64(self_k1);
+        oif_free_array_f64(self_k2);
+        oif_free_array_f64(self_k3);
+        oif_free_array_f64(self_k4);
+        oif_free_array_f64(self_k5);
+        oif_free_array_f64(self_k6);
+    }
+
+    self_N = y0_in->dimensions[0];
+
+    self_y = oif_create_array_f64(1, y0_in->dimensions);
+    if (self_y == NULL) {
+        fprintf(stderr, "[%s] Could not allocate memory for the solution vector\n", prefix_);
+        exit(1);
+    }
+    for (size_t i = 0; i < self_y->dimensions[0]; ++i) {
+        self_y->data[i] = y0_in->data[i];
+    }
+
+    self_yt = oif_create_array_f64(1, y0_in->dimensions);
+
+    self_k1 = oif_create_array_f64(1, y0_in->dimensions);
+    self_k2 = oif_create_array_f64(1, y0_in->dimensions);
+    self_k3 = oif_create_array_f64(1, y0_in->dimensions);
+    self_k4 = oif_create_array_f64(1, y0_in->dimensions);
+    self_k5 = oif_create_array_f64(1, y0_in->dimensions);
+    self_k6 = oif_create_array_f64(1, y0_in->dimensions);
+
+    self_y2 = oif_create_array_f64(1, y0_in->dimensions);
+    self_y3 = oif_create_array_f64(1, y0_in->dimensions);
+    self_y4 = oif_create_array_f64(1, y0_in->dimensions);
+    self_y5 = oif_create_array_f64(1, y0_in->dimensions);
+    self_y6 = oif_create_array_f64(1, y0_in->dimensions);
+
+    return 0;
+}
+
+int
+set_user_data(void *user_data)
+{
+    self_user_data = user_data;
+    return 0;
+}
+
+int
+set_rhs_fn(oif_ivp_rhs_fn_t rhs)
+{
+    if (rhs == NULL) {
+        fprintf(stderr, "[%s] `set_rhs_fn` accepts non-null function pointer only\n", prefix_);
+        return 1;
+    }
+    OIF_RHS_FN = rhs;
+    return 0;
+}
+
+int
+set_tolerances(double rtol, double atol)
+{
+    self_rtol = rtol;
+    self_atol = atol;
+    return 0;
+}
+
+int
+set_integrator(const char *integrator_name, OIFConfigDict *config_)
+{
+    (void) integrator_name;
+    (void) config_;
+    fprintf(stderr, "[%s] Method `set_integrator` is not supported\n", prefix_);
+    return 0;
+}
+
+int
+print_stats(void)
+{
+    return 0;
+}
+
+/**
+ * Write into `y` the updated solution at time `t`.
+ *
+ */
+int
+integrate(double t, OIFArrayF64 *y)
+{
+    fprintf(stderr, "[%s] integrate", prefix_);
+    if (t <= self_t) {
+        fprintf(stderr, "[%s] Time should be larger than the current time\n", prefix_);
+    }
+
+    double h = pow(10.0, 6);
+
+    OIF_RHS_FN(t, y, self_k1, self_user_data);
+
+    while (self_t < t) {
+        if (self_t + h > t) {
+            h = self_t - t;
+        }
+
+        // 2nd stage
+        for (int i = 0; i < self_N; ++i) {
+            self_y2->data[i] = self_y->data[i] + h / 5.0 * self_k1->data[i];
+        }
+        OIF_RHS_FN(t + h / 5.0, self_y2, self_k2, self_user_data);
+
+        // 3rd stage
+        for (int i = 0; i < self_N; ++i) {
+            self_y3->data[i] = self_y->data[i] + h / 40.0 * (
+                3 * self_k1->data[i] + 9 * self_k2->data[i]
+            );
+        }
+        OIF_RHS_FN(t + 3.0 * h / 10, self_y3, self_k3, self_user_data);
+
+        // 4th stage
+        for (int i = 0; i < self_N; ++i) {
+            self_y4->data[i] = self_y->data[i] + h * (
+                a4[1] * self_k1->data[i] +
+                a4[2] * self_k2->data[i] +
+                a4[3] * self_k3->data[i]
+            );
+        }
+        OIF_RHS_FN(t + 4.0 * h / 5, self_y4, self_k4, self_user_data);
+
+        // 5th stage
+        for (int i = 0; i < self_N; ++i) {
+            self_y5->data[i] = self_y->data[i] + h * (
+                a5[1] * self_k1->data[i] +
+                a5[2] * self_k2->data[i] +
+                a5[3] * self_k3->data[i] +
+                a5[4] * self_k4->data[i]
+            );
+        }
+        OIF_RHS_FN(t + 8.0 * h / 9, self_y5, self_k5, self_user_data);
+
+        // step 6.
+        for (int i = 0; i < self_N; ++i) {
+            self_y6->data[i] = self_y->data[i] + h * (
+                a6[1] * self_k1->data[i] +
+                a6[2] * self_k2->data[i] +
+                a6[3] * self_k3->data[i] +
+                a6[4] * self_k4->data[i] +
+                a6[5] * self_k5->data[i]
+            );
+        }
+        OIF_RHS_FN(t + h, self_y6, self_k6, self_user_data);
+
+        // Estimate less accurate.
+        for (size_t i = 0; i < self_y->dimensions[0]; ++i) {
+            self_yt->data[i] = y->data[i] + h * (
+                a7[1] * self_k1->data[i] + a7[3] * self_k3->data[i] +
+                a7[4] * self_k4->data[i] + a7[5] * self_k5->data[i] +
+                a7[6] * self_k6->data[i]
+            );
+        }
+        OIF_RHS_FN(t + h, self_yt, self_k2, self_user_data);
+
+        double err = 0.0;
+
+        for (size_t i = 0; i < self_N; ++i) {
+            double var = h * (
+                e[1] * self_k1->data[i] + e[2] * self_k2->data[i] +
+                e[3] * self_k3->data[i] + e[4] * self_k4->data[i] +
+                e[5] * self_k5->data[i] + e[6] * self_k6->data[i]
+            );
+            double sk = self_atol + self_rtol * MAX(fabs(self_y->data[i]), fabs(self_yt->data[i]));
+            err += pow(var / sk, 2);
+        }
+        err = sqrt(err / self_N);
+
+        // double FAC11 = err * EXP01;
+        double hnew = h * MIN(FACMAX, MAX(FACMIN, FAC * pow(1.0 / err, 1 / (ORDER_OF_ACC + 1.0))));
+
+        if (err < 1.0) {
+            // Solution accepted.
+            self_t += h;
+            OIFArrayF64 *tmp = self_k1;
+            self_k1 = self_k2;
+            self_k2 = tmp;
+
+            tmp = self_y;
+            self_y = self_yt;
+            self_yt = tmp;
+            FACMAX = FACMAX_DEFAULT;
+            fprintf(stderr, "[%s::integrate] step is accepted\n", prefix_);
+            n_rejected = 0;
+        }
+        else {
+            // Solution rejected.
+            // It is also advisable to put facmax = 1 in the steps
+            // right after a step-rejection (Shampine & Watts 1979).
+            // Hairer et. al., vol. 1, p. 168.
+            FACMAX = 1.0;
+            fprintf(stderr, "[%s::integrate] step is rejected\n", prefix_);
+            n_rejected++;
+        }
+
+        h = hnew;
+        fprintf(stderr, "[%s::integrate] h = %.16f\n", prefix_, h);
+
+        if (n_rejected > 20) {
+            fprintf(stderr, "[%s::integrate] Too many rejected steps\n", prefix_);
+            exit(1);
+        }
+    }
+
+    return 0;
+}

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -165,6 +165,7 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
             "[%s] Accept only one-dimensional arrays (vectors)\n",
             prefix_
         );
+        return 1;
     }
 
     if (self_y) {

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -365,28 +365,24 @@ integrate(double t_, OIFArrayF64 *y_out)
             // Step is accepted.
             FACOLD = MAX(err, 1.0e-4);
             self_t += self_h;
-            /* OIFArrayF64 *tmp = self_k1; */
-            /* self_k1 = self_k2; */
-            /* self_k2 = tmp; */
 
-            /* tmp = self_y; */
-            /* self_y = self_y1; */
-            /* self_yt = tmp; */
+            OIFArrayF64 *tmp = NULL;
 
-            for (int i = 0; i < self_N; ++i) {
-                self_k1->data[i] = self_k2->data[i];
-            }
+            // Instead of copying `self_k2` into `self_k1` we just swap pointers.
+            tmp = self_k1;
+            self_k1 = self_k2;
+            self_k2 = tmp;
 
-            for (int i = 0; i < self_N; ++i) {
+            // Instead of copying `self_y1` into `self_y` we just swap pointers.
+            tmp = self_y;
+            self_y = self_y1;
+            self_y1 = tmp;
 
-                self_y->data[i] = self_y1->data[i];
-            }
-
-            /* if (last) { */
+            if (last) {
                 for (int i = 0; i < self_N; ++i) {
                     y_out->data[i] = self_y->data[i];
                 }
-            /* } */
+            }
             n_rejected = 0;
         }
         else {

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -1,5 +1,10 @@
 /**
  * Implementation of the `ivp` interface with hand-written Dormand-Prince 5(4).
+ *
+ * Adaptive time step algorithm, computation of initial time step, and
+ * related constants are from
+ * Hairer et al. Solving Ordinary Differential Equations I, p. 167--169.
+ *
  */
 #include <assert.h>
 #include <limits.h>
@@ -73,7 +78,7 @@ double const FACMAX_DEFAULT = 1.5;
 double const FACMIN = 0.2;
 double const FAC = 0.8;
 double const ORDER_OF_ACC = 4;
-double FACMAX;  // FACMAX depends on step acceptance/rejection (see Hairer, vol. 1, p. 168)
+double FACMAX;
 
 size_t n_rejected = 0;
 

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.c
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.c
@@ -255,7 +255,6 @@ print_stats(void)
 int
 integrate(double t_, OIFArrayF64 *y_out)
 {
-    fprintf(stderr, "[%s] integrate", prefix_);
     if (t_ <= self_t) {
         fprintf(stderr, "[%s] Time should be larger than the current time\n", prefix_);
     }
@@ -377,7 +376,6 @@ integrate(double t_, OIFArrayF64 *y_out)
             for (int i = 0; i < self_N; ++i) {
                 self_k1->data[i] = self_k2->data[i];
             }
-            fprintf(stderr, "[%s::integrate] step is accepted\n", prefix_);
 
             for (int i = 0; i < self_N; ++i) {
 
@@ -398,12 +396,10 @@ integrate(double t_, OIFArrayF64 *y_out)
             // Hairer et. al., vol. 1, p. 168.
             /* FACMAX = 1.0; */
             hnew = self_h / MIN(FACC1, FAC11 / SAFE);
-            fprintf(stderr, "[%s::integrate] step is rejected\n", prefix_);
             n_rejected++;
         }
 
         self_h = hnew;
-        fprintf(stderr, "[%s::integrate] h = %.16f\n", prefix_, h);
 
         if (n_rejected > 20) {
             fprintf(stderr, "[%s::integrate] Too many rejected steps\n", prefix_);

--- a/oif_impl/impl/ivp/dopri5c/dopri5c.conf
+++ b/oif_impl/impl/ivp/dopri5c/dopri5c.conf
@@ -1,0 +1,2 @@
+c
+liboif_ivp_dopri5c.so

--- a/oif_impl/lang_c/dispatch_c.c
+++ b/oif_impl/lang_c/dispatch_c.c
@@ -74,7 +74,7 @@ unload_impl(ImplInfo *impl_info_)
 }
 
 int
-call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *out_args)
+call_impl(ImplInfo *impl_info_, const char *method, OIFArgs *in_args, OIFArgs *out_args)
 {
     int result = 1;
     ffi_cif cif;
@@ -82,13 +82,13 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
     void **arg_values = NULL;
     AllocationTracker *tracker = NULL;
 
-    if (impl_info->dh != OIF_LANG_C) {
+    if (impl_info_->dh != OIF_LANG_C) {
         fprintf(stderr, "[dispatch_c] Provided implementation is not implemented in C\n");
         return -1;
     }
 
-    CImplInfo *impl = (CImplInfo *)impl_info;
-    void *service_lib = impl->impl_lib;
+    CImplInfo *impl_info = (CImplInfo *)impl_info_;
+    void *service_lib = impl_info->impl_lib;
     void *func = dlsym(service_lib, method);
     if (func == NULL) {
         fprintf(stderr, "[dispatch_c] Cannot load interface '%s'\n", method);
@@ -112,17 +112,14 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
     }
 
     tracker = allocation_tracker_init();
-    assert(tracker != NULL);
 
     // Merge input and output argument types together in `arg_types` array.
-    for (size_t i = 0; i < num_in_args; ++i) {
+    for (unsigned int i = 0; i < num_in_args; ++i) {
         if (in_args->arg_types[i] == OIF_FLOAT64) {
             arg_types[i] = &ffi_type_double;
         }
-        else if (in_args->arg_types[i] == OIF_ARRAY_F64) {
-            arg_types[i] = &ffi_type_pointer;
-        }
-        else if (in_args->arg_types[i] == OIF_STR) {
+        else if (in_args->arg_types[i] == OIF_ARRAY_F64 ||
+            in_args->arg_types[i] == OIF_STR) {
             arg_types[i] = &ffi_type_pointer;
         }
         else if (in_args->arg_types[i] == OIF_CALLBACK) {
@@ -186,7 +183,7 @@ call_impl(ImplInfo *impl_info, const char *method, OIFArgs *in_args, OIFArgs *ou
         }
     }
 
-    for (size_t i = num_in_args; i < num_total_args; ++i) {
+    for (unsigned int i = num_in_args; i < num_total_args; ++i) {
         if (out_args->arg_types[i - num_in_args] == OIF_FLOAT64) {
             arg_types[i] = &ffi_type_double;
         }

--- a/oif_impl/lang_c/dispatch_c.c
+++ b/oif_impl/lang_c/dispatch_c.c
@@ -118,8 +118,7 @@ call_impl(ImplInfo *impl_info_, const char *method, OIFArgs *in_args, OIFArgs *o
         if (in_args->arg_types[i] == OIF_FLOAT64) {
             arg_types[i] = &ffi_type_double;
         }
-        else if (in_args->arg_types[i] == OIF_ARRAY_F64 ||
-            in_args->arg_types[i] == OIF_STR) {
+        else if (in_args->arg_types[i] == OIF_ARRAY_F64 || in_args->arg_types[i] == OIF_STR) {
             arg_types[i] = &ffi_type_pointer;
         }
         else if (in_args->arg_types[i] == OIF_CALLBACK) {

--- a/oif_impl/lang_c/include/oif_impl/ivp.h
+++ b/oif_impl/lang_c/include/oif_impl/ivp.h
@@ -37,3 +37,9 @@ oif_ivp_integrate(double t, OIFArrayF64 *y);
  */
 int
 oif_ivp_set_integrator(const char *integrator_name, OIFConfigDict *config);
+
+/**
+ * Print statistics about integration process.
+ */
+int
+oif_ivp_print_stats();


### PR DESCRIPTION
**Changes**:
- Add `IVP::dopri5c` implementation (C implementation of a Dorman--Prince 5(4) method)
- Fix a memory leak in `AllocationTracker`
- Add a (gcc-supported) destructor for a shared library `liboif_dispatch` that warns about running a non-optimized build
  (to help avoiding situations when a performance study is done against a debug guild)