### PR TITLE
[misc] Make env.sh source'able not only in ZSH but also in Bash

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -1,8 +1,13 @@
 # Set project root directory to use absolute paths below.
+export PRJ_ROOT_DIR=""
 if [ "$GITHUB_ACTIONS" = "true" ]; then
-    export PRJ_ROOT_DIR="$GITHUB_WORKSPACE"
+    PRJ_ROOT_DIR="$GITHUB_WORKSPACE"
 else
-    export PRJ_ROOT_DIR="$(dirname $(realpath "$0"))"
+    if [ "$0" = "-bash" ]; then
+        PRJ_ROOT_DIR="$(dirname "$(realpath ${BASH_SOURCE[0]})")"
+    else
+        PRJ_ROOT_DIR="$(dirname "$(realpath "$0")")"
+    fi
 fi
 
 # Set path to implementations


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Update `env.sh` to be source'able not only from ZSH, but also from the Bash shell.

For an unknown reason, these two shells contain the path to the sourced script in different variables.