### PR TITLE
[python] Fix imports in examples

### DIFF
--- a/examples/call_ivp_from_python.py
+++ b/examples/call_ivp_from_python.py
@@ -2,7 +2,7 @@ import argparse
 import dataclasses
 
 import numpy as np
-from oif.interfaces.ivp import IVP
+from openinterfaces.interfaces.ivp import IVP
 
 
 @dataclasses.dataclass

--- a/examples/call_ivp_from_python_burgers_eq.py
+++ b/examples/call_ivp_from_python_burgers_eq.py
@@ -4,7 +4,7 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-from oif.interfaces.ivp import IVP
+from openinterfaces.interfaces.ivp import IVP
 
 
 @dataclasses.dataclass

--- a/examples/call_ivp_from_python_vdp.py
+++ b/examples/call_ivp_from_python_vdp.py
@@ -4,7 +4,7 @@ import os
 
 import matplotlib.pyplot as plt
 import numpy as np
-from oif.interfaces.ivp import IVP
+from openinterfaces.interfaces.ivp import IVP
 
 RESULT_DATA_FILENAME_TPL = "ivp_py_vdp_eq_{:s}.txt"
 RESULT_FIG_FILENAME_TPL = "ivp_py_vdp_eq_{:s}.pdf"

--- a/examples/call_qeq_from_python.py
+++ b/examples/call_qeq_from_python.py
@@ -1,7 +1,7 @@
 import argparse
 import dataclasses
 
-from oif.interfaces.qeq import QEQ
+from openinterfaces.interfaces.qeq import QEQ
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Fix outdates imports `import oif....` to `import openinterfaces` in the `examples` Python scripts