### PR TITLE
Fix memory leaks in OIFConfigDict destructor function

### DIFF
--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -86,9 +86,18 @@ oif_config_dict_free(void *_dict)
     assert(dict->type == OIF_CONFIG_DICT);
     const char *key;
     OIFConfigEntry *entry;
-    hashmap_foreach(key, entry, &dict->map) { free(entry->value); }
+    hashmap_foreach(key, entry, &dict->map)
+    {
+        free(entry->value);
+        free(entry);
+    }
     hashmap_cleanup(&dict->map);
-    free(dict->buffer);
+    if (dict->buffer) {
+        free(dict->buffer);
+    }
+    if (dict->pc) {
+        free(dict->pc);
+    }
     free(dict);
 }
 


### PR DESCRIPTION
# MaRDI Pull Request

While attempting to fix memory problems that somehow appeared after implementing the `ivp::set_integrator` method in the `IVP` Gateway in Julia, I have used the AddressSanitizer of GCC and have found memory leaks in the `oif_config_dict.c` module.

This small PR fixes these memory leaks.