### PR TITLE
Fix multiple memory leaks and issues

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ BasedOnStyle: Google
 AlwaysBreakAfterReturnType: All
 AllowShortIfStatementsOnASingleLine: false
 AlignAfterOpenBracket: Align
+AlignEscapedNewlines: LeftWithLastLine
 BreakBeforeBraces: Stroustrup
 ColumnLimit: 95
 DerivePointerAlignment: false

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -17,6 +17,6 @@ target_include_directories(oif_common_data_structures
                            PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(oif_common_data_structures
                            PRIVATE ${cwpack_SOURCE_DIR}/src)
-target_link_libraries(oif_common_data_structures PRIVATE oif_common_util)
+target_link_libraries(oif_common_data_structures PUBLIC oif_common_util)
 target_link_libraries(oif_common_data_structures PRIVATE HashMap::HashMap)
 install(TARGETS oif_common_data_structures DESTINATION lib)

--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -169,7 +169,7 @@ oif_config_dict_add_str(OIFConfigDict *dict, const char *key, const char *value)
 const char **
 oif_config_dict_get_keys(OIFConfigDict *dict)
 {
-    const char **keys = oif_util_malloc(dict->size * sizeof(char *));
+    const char **keys = oif_util_malloc((dict->size + 1) * sizeof(char *));
     if (keys == NULL) {
         fprintf(stderr, "Could not allocate memory for keys\n");
         exit(1);

--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -82,6 +82,9 @@ oif_config_dict_init(void)
 void
 oif_config_dict_free(void *_dict)
 {
+    if (_dict == NULL) {
+        return;
+    }
     OIFConfigDict *dict = _dict;
     assert(dict->type == OIF_CONFIG_DICT);
     const char *key;
@@ -460,13 +463,14 @@ oif_config_dict_copy_serialization(OIFConfigDict *to, const OIFConfigDict *from)
                 "at the destination was already initialized\n");
         return 1;
     }
-    to->buffer = oif_util_malloc(from->buffer_length * sizeof(*from->buffer));
+    to->buffer = oif_util_malloc((from->buffer_length + 1) * sizeof(*from->buffer));
     if (to->buffer == NULL) {
         fprintf(stderr, "Memory error\n");
         exit(1);
     }
     memcpy(to->buffer, from->buffer, from->buffer_length);
     to->buffer_length = from->buffer_length;
+    to->buffer[to->buffer_length] = '\0';  // Ensure null-termination.
     return 0;
 }
 

--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -102,6 +102,7 @@ oif_config_dict_free(void *_dict)
         oif_util_free(dict->pc);
     }
     oif_util_free(dict);
+    dict = NULL;
 }
 
 void

--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -34,7 +34,7 @@ static size_t SIZE_ = 65;
 static char *
 copy_key_(const char *key)
 {
-    char *key_copy = malloc((strlen(key) + 1) * sizeof(char));
+    char *key_copy = oif_util_malloc((strlen(key) + 1) * sizeof(char));
     if (key_copy == NULL) {
         fprintf(stderr, "Could not allocate memory for a key copy\n");
         exit(1);
@@ -46,7 +46,7 @@ copy_key_(const char *key)
 static void
 free_key_(char *key)
 {
-    free(key);
+    oif_util_free(key);
 }
 
 inline static uint8_t *
@@ -64,7 +64,7 @@ reallocate_buffer_(uint8_t *buffer, size_t new_buffer_size)
 OIFConfigDict *
 oif_config_dict_init(void)
 {
-    OIFConfigDict *dict = malloc(sizeof(OIFConfigDict));
+    OIFConfigDict *dict = oif_util_malloc(sizeof(OIFConfigDict));
     assert(dict != NULL);
 
     dict->type = OIF_CONFIG_DICT;
@@ -88,29 +88,29 @@ oif_config_dict_free(void *_dict)
     OIFConfigEntry *entry;
     hashmap_foreach(key, entry, &dict->map)
     {
-        free(entry->value);
-        free(entry);
+        oif_util_free(entry->value);
+        oif_util_free(entry);
     }
     hashmap_cleanup(&dict->map);
     if (dict->buffer) {
-        free(dict->buffer);
+        oif_util_free(dict->buffer);
     }
     if (dict->pc) {
-        free(dict->pc);
+        oif_util_free(dict->pc);
     }
-    free(dict);
+    oif_util_free(dict);
 }
 
 void
 oif_config_dict_add_int(OIFConfigDict *dict, const char *key, int value)
 {
-    OIFConfigEntry *entry = malloc(sizeof(OIFConfigEntry));
+    OIFConfigEntry *entry = oif_util_malloc(sizeof(OIFConfigEntry));
     if (entry == NULL) {
         fprintf(stderr, "Could not add an entry to the config dictionary\n");
         exit(1);
     }
     entry->type = OIF_INT;
-    entry->value = malloc(sizeof(int));
+    entry->value = oif_util_malloc(sizeof(int));
     if (entry->value == NULL) {
         fprintf(stderr, "Could not allocate memory for adding an int entry\n");
         exit(1);
@@ -126,13 +126,13 @@ oif_config_dict_add_int(OIFConfigDict *dict, const char *key, int value)
 void
 oif_config_dict_add_double(OIFConfigDict *dict, const char *key, double value)
 {
-    OIFConfigEntry *entry = malloc(sizeof(OIFConfigEntry));
+    OIFConfigEntry *entry = oif_util_malloc(sizeof(OIFConfigEntry));
     if (entry == NULL) {
         fprintf(stderr, "Could not add an entry to the config dictionary\n");
         exit(1);
     }
     entry->type = OIF_FLOAT64;
-    entry->value = malloc(sizeof(double));
+    entry->value = oif_util_malloc(sizeof(double));
     if (entry->value == NULL) {
         fprintf(stderr, "Could not allocate memory for adding a double entry\n");
         exit(1);
@@ -148,7 +148,7 @@ oif_config_dict_add_double(OIFConfigDict *dict, const char *key, double value)
 void
 oif_config_dict_add_str(OIFConfigDict *dict, const char *key, const char *value)
 {
-    OIFConfigEntry *entry = malloc(sizeof(OIFConfigEntry));
+    OIFConfigEntry *entry = oif_util_malloc(sizeof(OIFConfigEntry));
     if (entry == NULL) {
         fprintf(stderr, "Could not add an entry to the config dictionary\n");
         exit(1);
@@ -169,7 +169,7 @@ oif_config_dict_add_str(OIFConfigDict *dict, const char *key, const char *value)
 const char **
 oif_config_dict_get_keys(OIFConfigDict *dict)
 {
-    const char **keys = malloc(dict->size * sizeof(char *));
+    const char **keys = oif_util_malloc(dict->size * sizeof(char *));
     if (keys == NULL) {
         fprintf(stderr, "Could not allocate memory for keys\n");
         exit(1);
@@ -276,7 +276,7 @@ oif_config_dict_print(OIFConfigDict *dict)
 void
 oif_config_dict_serialize(OIFConfigDict *dict)
 {
-    cw_pack_context *pc = malloc(sizeof(*pc));
+    cw_pack_context *pc = oif_util_malloc(sizeof(*pc));
     if (pc == NULL) {
         fprintf(stderr,
                 "Could not allocate memory required for serializing a config dictionary\n");
@@ -284,7 +284,7 @@ oif_config_dict_serialize(OIFConfigDict *dict)
     }
 
     size_t buffer_size = BUF_SIZE_;
-    uint8_t *buffer = malloc(buffer_size * sizeof(uint8_t));
+    uint8_t *buffer = oif_util_malloc(buffer_size * sizeof(uint8_t));
     if (buffer == NULL) {
         fprintf(stderr, "Could not allocate memory\n");
         exit(1);
@@ -460,7 +460,7 @@ oif_config_dict_copy_serialization(OIFConfigDict *to, const OIFConfigDict *from)
                 "at the destination was already initialized\n");
         return 1;
     }
-    to->buffer = malloc(from->buffer_length * sizeof(*from->buffer));
+    to->buffer = oif_util_malloc(from->buffer_length * sizeof(*from->buffer));
     if (to->buffer == NULL) {
         fprintf(stderr, "Memory error\n");
         exit(1);

--- a/common/util.c
+++ b/common/util.c
@@ -1,4 +1,6 @@
+#define _GNU_SOURCE
 #include <ctype.h>
+#include <dlfcn.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -6,6 +8,94 @@
 #include <stdlib.h>
 
 #include <oif/util.h>
+
+static size_t NALLOCS_ = 0;
+static size_t NBYTES_ = 0;
+
+void *oif_util_malloc_(size_t nbytes) {
+    // void *addr = __builtin_return_address(0);
+    // Dl_info info;
+    // if (dladdr(addr, &info) && info.dli_fname) {
+    //     fprintf(
+    //         stderr,
+    //         "\033[31m"
+    //         "[oif_util_malloc]"
+    //         "\033[0m"
+    //         " Allocating %zu bytes of memory (total allocs: %zu)\n"
+    //         "                  File: %s\n"
+    //         "              Function: %s\n"
+    //         "                  Line: %d\n",
+    //         nbytes, NALLOCS_ + 1, info.dli_fname, info.dli_sname, __LINE__
+    //     );
+    // } else {
+    //     fprintf(stderr, "[oif_util_malloc] Could not retrieve caller information\n");
+    // }
+
+    // void *p_raw = malloc(nbytes + sizeof(size_t));
+    // if (p_raw == NULL) {
+    //     fprintf(stderr, "Could not allocate memory\n");
+    //     exit(1);
+    // }
+    // NALLOCS_++;
+    // NBYTES_ += nbytes;
+
+    // size_t *p2 = (size_t *)p_raw;
+    // *p2 = nbytes;
+    // void *p_oif = (void *)(p2 + 1);
+    // fprintf(stderr, "Pointer malloc: %p\n", p_raw);
+    // fprintf(stderr, "    Size in it: %zu bytes\n", nbytes);
+    // fprintf(stderr, "   Pointer oif: %p\n", p_oif);
+    //
+    void *p_oif = malloc(nbytes);
+    NALLOCS_++;
+
+    return p_oif;
+}
+
+void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line) {
+    fprintf(
+        stderr,
+        "\033[31m"
+        "[oif_util_malloc]"
+        "\033[0m"
+        " Allocating %zu bytes of memory\n"
+        "                  File: %s\n"
+        "              Function: %s\n"
+        "                  Line: %d\n",
+        nbytes, file, func, line
+    );
+    return oif_util_malloc_(nbytes);
+}
+
+void oif_util_free_(void *ptr) {
+    if (ptr == NULL) {
+        fprintf(stderr, "Cannot free a NULL pointer\n");
+        exit(1);
+    }
+
+    size_t *p_oif = (size_t *)ptr;
+    // size_t *p_raw = p_oif - 1;
+    // size_t nbytes = *p_raw;
+    // fprintf(stderr, "Pointer to free: %p\n", ptr);
+    // fprintf(stderr, "    Pointer raw: %p\n", p_raw);
+    // fprintf(stderr, "     Size in it: %zu bytes\n", nbytes);
+    free(p_oif);
+    p_oif = NULL;
+    NALLOCS_--;
+    // NBYTES_ -= nbytes;
+}
+
+void oif_util_free_verbose(void *ptr, const char *file, const char *func, int line) {
+    fprintf(
+        stderr,
+        "\033[31m[oif_util_free]\033[0m Freeing memory\n"
+        "                  File: %s\n"
+        "              Function: %s\n"
+        "                  Line: %d\n",
+        file, func, line
+    );
+    oif_util_free_(ptr);
+}
 
 uint32_t
 oif_util_u32_from_size_t(size_t val)
@@ -26,8 +116,23 @@ oif_util_u32_from_size_t(size_t val)
 char *
 oif_util_str_duplicate(const char *src)
 {
+    void *addr = __builtin_return_address(0);
+    Dl_info info;
+    if (dladdr(addr, &info) && info.dli_fname) {
+        fprintf(
+            stderr,
+            "\033[31m[oif_util_str_duplicate]\033[0m\n"
+            "        File: %s\n"
+            "    Function: %s\n"
+            "        Line: %d\n",
+            info.dli_fname,
+            info.dli_sname,
+            __LINE__);
+    } else {
+        fprintf(stderr, "[str_duplicate] Could not retrieve caller information\n");
+    }
     size_t len = strlen(src);
-    char *dest = malloc((len + 1) * sizeof(*dest));
+    char *dest = oif_util_malloc_((len + 1) * sizeof(*dest));
     if (dest == NULL) {
         fprintf(stderr, "[str_duplicate] Could not allocate memory\n");
         return NULL;
@@ -69,3 +174,15 @@ logerr(const char *prefix, const char *fmt, ...)
 
     return 0;
 }
+
+
+#if defined(__GNUC__)
+#if !defined(__OPTIMIZE__)
+void __attribute((destructor))
+oif_util_dtor_(void) {
+    fprintf(stderr, "[oif_util] Final statistics on memory allocs via malloc/free:\n");
+    fprintf(stderr, "[oif_util] Number of not-freed allocations: %zu\n", NALLOCS_);
+    // fprintf(stderr, "[oif_util] Number of not-freed bytes: %zu\n", NBYTES_);
+}
+#endif
+#endif

--- a/common/util.c
+++ b/common/util.c
@@ -176,6 +176,21 @@ oif_util_str_contains(const char **arr, const char *s)
 }
 
 int
+logwarn(const char *prefix, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+
+    fprintf(stderr, "[%s] \033[1m\033[33mWARNING:\033[0m ", prefix);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+
+    va_end(ap);
+
+    return 0;
+}
+
+int
 logerr(const char *prefix, const char *fmt, ...)
 {
     va_list ap;

--- a/common/util.c
+++ b/common/util.c
@@ -180,9 +180,13 @@ logerr(const char *prefix, const char *fmt, ...)
 #if !defined(__OPTIMIZE__)
 void __attribute((destructor))
 oif_util_dtor_(void) {
-    fprintf(stderr, "[oif_util] Final statistics on memory allocs via malloc/free:\n");
-    fprintf(stderr, "[oif_util] Number of not-freed allocations: %zu\n", NALLOCS_);
+    fprintf(stderr, "\033[31m[oif_util]\033[0m Final statistics on memory allocs via malloc/free:\n");
+    fprintf(stderr, "\033[31m[oif_util]\033[0m Number of not-freed allocations: %zu\n", NALLOCS_);
     // fprintf(stderr, "[oif_util] Number of not-freed bytes: %zu\n", NBYTES_);
+    if (NALLOCS_ > 0) {
+        fprintf(stderr, "\033[31m[oif_util]\033[0m Memory leaks detected!\n");
+        exit(1);
+    }
 }
 #endif
 #endif

--- a/common/util.c
+++ b/common/util.c
@@ -118,23 +118,8 @@ oif_util_u32_from_size_t(size_t val)
 }
 
 char *
-oif_util_str_duplicate(const char *src)
+oif_util_str_duplicate_(const char *src)
 {
-    void *addr = __builtin_return_address(0);
-    Dl_info info;
-    if (dladdr(addr, &info) && info.dli_fname) {
-        fprintf(
-            stderr,
-            "\033[31m[oif_util_str_duplicate]\033[0m\n"
-            "        File: %s\n"
-            "    Function: %s\n"
-            "        Line: %d\n",
-            info.dli_fname,
-            info.dli_sname,
-            __LINE__);
-    } else {
-        fprintf(stderr, "[str_duplicate] Could not retrieve caller information\n");
-    }
     size_t len = strlen(src);
     char *dest = oif_util_malloc_((len + 1) * sizeof(*dest));
     if (dest == NULL) {
@@ -143,6 +128,23 @@ oif_util_str_duplicate(const char *src)
     }
     strcpy(dest, src);
     return dest;
+}
+
+char *
+oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line)
+{
+    fprintf(
+        stderr,
+        "\033[31m"
+        "[oif_util_str_duplicate]"
+        "\033[0m"
+        " Duplicate string '%s'\n"
+        "                  File: %s\n"
+        "              Function: %s\n"
+        "                  Line: %d\n",
+        src, file, func, line
+    );
+    return oif_util_str_duplicate_(src);
 }
 
 int

--- a/common/util.c
+++ b/common/util.c
@@ -160,6 +160,17 @@ oif_strcmp_nocase(const char s1[static 1], const char s2[static 1])
     return 0;
 }
 
+bool
+oif_util_str_contains(const char **arr, const char *s)
+{
+    for (size_t i = 0; arr[i] != NULL; ++i) {
+        if (strcmp(arr[i], s) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int
 logerr(const char *prefix, const char *fmt, ...)
 {

--- a/common/util.c
+++ b/common/util.c
@@ -13,24 +13,6 @@ static size_t NALLOCS_ = 0;
 static size_t NBYTES_ = 0;
 
 void *oif_util_malloc_(size_t nbytes) {
-    // void *addr = __builtin_return_address(0);
-    // Dl_info info;
-    // if (dladdr(addr, &info) && info.dli_fname) {
-    //     fprintf(
-    //         stderr,
-    //         "\033[31m"
-    //         "[oif_util_malloc]"
-    //         "\033[0m"
-    //         " Allocating %zu bytes of memory (total allocs: %zu)\n"
-    //         "                  File: %s\n"
-    //         "              Function: %s\n"
-    //         "                  Line: %d\n",
-    //         nbytes, NALLOCS_ + 1, info.dli_fname, info.dli_sname, __LINE__
-    //     );
-    // } else {
-    //     fprintf(stderr, "[oif_util_malloc] Could not retrieve caller information\n");
-    // }
-
     // void *p_raw = malloc(nbytes + sizeof(size_t));
     // if (p_raw == NULL) {
     //     fprintf(stderr, "Could not allocate memory\n");

--- a/common/util.c
+++ b/common/util.c
@@ -81,6 +81,10 @@ void oif_util_free_(void *ptr) {
     // fprintf(stderr, "     Size in it: %zu bytes\n", nbytes);
     free(p_oif);
     p_oif = NULL;
+    if (NALLOCS_ == 0) {
+        fprintf(stderr, "\033[31m[oif_util_free] ERROR:\033[0m For some reason, number of non-freed allocations is already zero. Exiting...\n");
+        exit(1);
+    }
     NALLOCS_--;
     // NBYTES_ -= nbytes;
 }

--- a/common/util.c
+++ b/common/util.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 
 #include <oif/util.h>
+#include <oif/_platform.h>
 
 static size_t NALLOCS_ = 0;
 static size_t NBYTES_ = 0;
@@ -35,6 +36,7 @@ void *oif_util_malloc_(size_t nbytes) {
 }
 
 void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line) {
+#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
     fprintf(
         stderr,
         "\033[31m"
@@ -46,6 +48,11 @@ void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func,
         "                  Line: %d\n",
         nbytes, file, func, line
     );
+#else
+    (void)file;  // Suppress unused parameter warning
+    (void)func;  // Suppress unused parameter warning
+    (void)line;  // Suppress unused parameter warning
+#endif
     return oif_util_malloc_(nbytes);
 }
 
@@ -72,6 +79,7 @@ void oif_util_free_(void *ptr) {
 }
 
 void oif_util_free_verbose(void *ptr, const char *file, const char *func, int line) {
+#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
     fprintf(
         stderr,
         "\033[31m[oif_util_free]\033[0m Freeing memory\n"
@@ -80,6 +88,11 @@ void oif_util_free_verbose(void *ptr, const char *file, const char *func, int li
         "                  Line: %d\n",
         file, func, line
     );
+#else
+    (void)file;  // Suppress unused parameter warning
+    (void)func;  // Suppress unused parameter warning
+    (void)line;  // Suppress unused parameter warning
+#endif
     oif_util_free_(ptr);
 }
 
@@ -115,6 +128,7 @@ oif_util_str_duplicate_(const char *src)
 char *
 oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line)
 {
+#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
     fprintf(
         stderr,
         "\033[31m"
@@ -126,6 +140,11 @@ oif_util_str_duplicate_verbose(const char *src, const char *file, const char *fu
         "                  Line: %d\n",
         src, file, func, line
     );
+#else
+    (void)file;  // Suppress unused parameter warning
+    (void)func;  // Suppress unused parameter warning
+    (void)line;  // Suppress unused parameter warning
+#endif
     return oif_util_str_duplicate_(src);
 }
 

--- a/common/util.c
+++ b/common/util.c
@@ -13,7 +13,9 @@
 static size_t NALLOCS_ = 0;
 static size_t NBYTES_ = 0;
 
-void *oif_util_malloc_(size_t nbytes) {
+void *
+oif_util_malloc_(size_t nbytes)
+{
     // void *p_raw = malloc(nbytes + sizeof(size_t));
     // if (p_raw == NULL) {
     //     fprintf(stderr, "Could not allocate memory\n");
@@ -35,19 +37,19 @@ void *oif_util_malloc_(size_t nbytes) {
     return p_oif;
 }
 
-void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line) {
+void *
+oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line)
+{
 #if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
-    fprintf(
-        stderr,
-        "\033[31m"
-        "[oif_util_malloc]"
-        "\033[0m"
-        " Allocating %zu bytes of memory\n"
-        "                  File: %s\n"
-        "              Function: %s\n"
-        "                  Line: %d\n",
-        nbytes, file, func, line
-    );
+    fprintf(stderr,
+            "\033[31m"
+            "[oif_util_malloc]"
+            "\033[0m"
+            " Allocating %zu bytes of memory\n"
+            "                  File: %s\n"
+            "              Function: %s\n"
+            "                  Line: %d\n",
+            nbytes, file, func, line);
 #else
     (void)file;  // Suppress unused parameter warning
     (void)func;  // Suppress unused parameter warning
@@ -56,7 +58,9 @@ void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func,
     return oif_util_malloc_(nbytes);
 }
 
-void oif_util_free_(void *ptr) {
+void
+oif_util_free_(void *ptr)
+{
     if (ptr == NULL) {
         fprintf(stderr, "Cannot free a NULL pointer\n");
         exit(1);
@@ -71,23 +75,25 @@ void oif_util_free_(void *ptr) {
     free(p_oif);
     p_oif = NULL;
     if (NALLOCS_ == 0) {
-        fprintf(stderr, "\033[31m[oif_util_free] ERROR:\033[0m For some reason, number of non-freed allocations is already zero. Exiting...\n");
+        fprintf(stderr,
+                "\033[31m[oif_util_free] ERROR:\033[0m For some reason, number of non-freed "
+                "allocations is already zero. Exiting...\n");
         exit(1);
     }
     NALLOCS_--;
     // NBYTES_ -= nbytes;
 }
 
-void oif_util_free_verbose(void *ptr, const char *file, const char *func, int line) {
+void
+oif_util_free_verbose(void *ptr, const char *file, const char *func, int line)
+{
 #if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
-    fprintf(
-        stderr,
-        "\033[31m[oif_util_free]\033[0m Freeing memory\n"
-        "                  File: %s\n"
-        "              Function: %s\n"
-        "                  Line: %d\n",
-        file, func, line
-    );
+    fprintf(stderr,
+            "\033[31m[oif_util_free]\033[0m Freeing memory\n"
+            "                  File: %s\n"
+            "              Function: %s\n"
+            "                  Line: %d\n",
+            file, func, line);
 #else
     (void)file;  // Suppress unused parameter warning
     (void)func;  // Suppress unused parameter warning
@@ -129,17 +135,15 @@ char *
 oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line)
 {
 #if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
-    fprintf(
-        stderr,
-        "\033[31m"
-        "[oif_util_str_duplicate]"
-        "\033[0m"
-        " Duplicate string '%s'\n"
-        "                  File: %s\n"
-        "              Function: %s\n"
-        "                  Line: %d\n",
-        src, file, func, line
-    );
+    fprintf(stderr,
+            "\033[31m"
+            "[oif_util_str_duplicate]"
+            "\033[0m"
+            " Duplicate string '%s'\n"
+            "                  File: %s\n"
+            "              Function: %s\n"
+            "                  Line: %d\n",
+            src, file, func, line);
 #else
     (void)file;  // Suppress unused parameter warning
     (void)func;  // Suppress unused parameter warning
@@ -208,13 +212,15 @@ logerr(const char *prefix, const char *fmt, ...)
     return 0;
 }
 
-
 #if defined(__GNUC__)
 #if !defined(__OPTIMIZE__)
 void __attribute((destructor))
-oif_util_dtor_(void) {
-    fprintf(stderr, "\033[31m[oif_util]\033[0m Final statistics on memory allocs via malloc/free:\n");
-    fprintf(stderr, "\033[31m[oif_util]\033[0m Number of not-freed allocations: %zu\n", NALLOCS_);
+oif_util_dtor_(void)
+{
+    fprintf(stderr,
+            "\033[31m[oif_util]\033[0m Final statistics on memory allocs via malloc/free:\n");
+    fprintf(stderr, "\033[31m[oif_util]\033[0m Number of not-freed allocations: %zu\n",
+            NALLOCS_);
     // fprintf(stderr, "[oif_util] Number of not-freed bytes: %zu\n", NBYTES_);
     if (NALLOCS_ > 0) {
         fprintf(stderr, "\033[31m[oif_util]\033[0m Memory leaks detected!\n");

--- a/dispatch/dispatch.c
+++ b/dispatch/dispatch.c
@@ -297,7 +297,7 @@ unload_interface_impl(ImplHandle implh)
                 "from the implementations table.");
     }
     oif_util_free(impl_info->interface);
-    free(impl_info);
+    oif_util_free(impl_info);
     impl_info = NULL;
     printf("[dispatch] Unloaded implementation with id '%d'\n", implh);
 

--- a/dispatch/dispatch.c
+++ b/dispatch/dispatch.c
@@ -130,14 +130,14 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
         fprintf(stderr, "[dispatch] Cannot open conf file '%s'\n", conf_filename_fixed_part);
         fprintf(stderr, "[dispatch] Search was done in the following paths: %s\n",
                 oif_impl_path_dup);
-        free(oif_impl_path_dup);
+        oif_util_free(oif_impl_path_dup);
         perror("Error message is: ");
         return -1;
     }
     else {
         fprintf(stderr, "[dispatch] Configuration file: %s\n", conf_filename);
     }
-    free(oif_impl_path_dup);
+    oif_util_free(oif_impl_path_dup);
 
     // Temporary buffer to read lines from file.
     const int buffer_size = 512;
@@ -296,7 +296,7 @@ unload_interface_impl(ImplHandle implh)
                 "[dispatch] Error occured when unloading implementation "
                 "from the implementations table.");
     }
-    free(impl_info->interface);
+    oif_util_free(impl_info->interface);
     free(impl_info);
     impl_info = NULL;
     printf("[dispatch] Unloaded implementation with id '%d'\n", implh);

--- a/dispatch/dispatch.c
+++ b/dispatch/dispatch.c
@@ -143,7 +143,7 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
     const int buffer_size = 512;
     size_t len;
     char *fgets_status;
-    buffer = malloc(sizeof(char) * buffer_size);
+    buffer = oif_util_malloc(sizeof(char) * buffer_size);
     if (buffer == NULL) {
         fprintf(stderr,
                 "[dispatch] Could not allocate buffer for parsing "
@@ -247,7 +247,7 @@ load_interface_impl(const char *interface, const char *impl, size_t version_majo
 
 cleanup:
     if (buffer != NULL) {
-        free(buffer);
+        oif_util_free(buffer);
     }
     if (conf_file != NULL) {
         fclose(conf_file);

--- a/dispatch/dispatch.c
+++ b/dispatch/dispatch.c
@@ -293,7 +293,7 @@ unload_interface_impl(ImplHandle implh)
     ImplInfo *result = hashmap_remove(&IMPL_MAP, &implh);
     if (result == NULL || result->implh != implh) {
         fprintf(stderr,
-                "[dispatch] Error occured when unloading implementation "
+                "[dispatch] Error occurred when unloading implementation "
                 "from the implementations table.");
     }
     oif_util_free(impl_info->interface);

--- a/include/oif/_platform.h
+++ b/include/oif/_platform.h
@@ -1,16 +1,12 @@
 // clang-format Language: C
 #pragma once
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
 #if !defined(static_assert)
 #define static_assert _Static_assert
 #endif
+#endif
 
-#ifdef __cplusplus
-}
 #if defined(__SANITIZE_ADDRESS__)
     #define OIF_SANITIZE_ADDRESS_ENABLED 1
 #endif

--- a/include/oif/_platform.h
+++ b/include/oif/_platform.h
@@ -22,3 +22,7 @@
 //     ...Function implementation...
 // }
 
+#if defined(__GNUC__) && !defined(__OPTIMIZE__)
+#define OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO
+#else
+#endif

--- a/include/oif/_platform.h
+++ b/include/oif/_platform.h
@@ -8,13 +8,13 @@
 #endif
 
 #if defined(__SANITIZE_ADDRESS__)
-    #define OIF_SANITIZE_ADDRESS_ENABLED 1
+#define OIF_SANITIZE_ADDRESS_ENABLED 1
 #endif
 
-#if defined(__clang__) || defined (__GNUC__)
-# define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#if defined(__clang__) || defined(__GNUC__)
+#define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
 #else
-# define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS
+#define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif
 // Usage example:
 // OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS

--- a/include/oif/_platform.h
+++ b/include/oif/_platform.h
@@ -11,4 +11,18 @@ extern "C" {
 
 #ifdef __cplusplus
 }
+#if defined(__SANITIZE_ADDRESS__)
+    #define OIF_SANITIZE_ADDRESS_ENABLED 1
 #endif
+
+#if defined(__clang__) || defined (__GNUC__)
+# define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+#else
+# define OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS
+#endif
+// Usage example:
+// OIF_ATTRIBUTE_NO_SANITIZE_ADDRESS
+// void my_function()  {
+//     ...Function implementation...
+// }
+

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -9,6 +9,29 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 
+void *oif_util_malloc_(size_t nbytes);
+void oif_util_free_(void *ptr);
+
+void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line);
+void oif_util_free_verbose(void *ptr, const char *file, const char *func, int line);
+
+/**
+ * Wrap `malloc` to collect debugging information about allocated memory.
+ *
+ * The function also does a check and **exits if the `malloc` fails**.
+ * The reason for exiting is that if we cannot allocate memory,
+ * then something is really wrong with the system,
+ * and there is no point to continue.
+ *
+ * @param nbytes Number of bytes to allocate.
+ * @return Pointer to the allocated memory.
+ */
+#define oif_util_malloc(nbytes) \
+        oif_util_malloc_verbose((nbytes), __FILE__, __func__, __LINE__)
+
+#define oif_util_free(ptr) \
+        oif_util_free_verbose((ptr), __FILE__, __func__, __LINE__)
+
 /**
  * Convert `size_t` input to `uint32_t`.
  *

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -52,7 +52,13 @@ oif_util_u32_from_size_t(size_t val);
  * of an error.
  */
 char *
-oif_util_str_duplicate(const char *src);
+oif_util_str_duplicate_(const char *src);
+
+char *
+oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line);
+
+#define oif_util_str_duplicate(src) \
+        oif_util_str_duplicate_verbose((src), __FILE__, __func__, __LINE__)
 
 /**
  * Compare two C strings case-insensitively.

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -73,6 +73,19 @@ bool
 oif_util_str_contains(const char **arr, const char *s);
 
 /**
+ * Log a warning message to stderr.
+ *
+ * The error message starts with "[prefix] WARNING: "
+ * followed by the formatted message.
+ *
+ * @param prefix The prefix to be printed before the message.
+ * @param fmt The format string for the message.
+ * @param ... The arguments for the format string.
+ */
+int
+logwarn(const char *prefix, const char *fmt, ...);
+
+/**
  * Log an error message to stderr.
  *
  * The error message starts with "[prefix] ERROR: "

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -10,11 +10,15 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 
-void *oif_util_malloc_(size_t nbytes);
-void oif_util_free_(void *ptr);
+void *
+oif_util_malloc_(size_t nbytes);
+void
+oif_util_free_(void *ptr);
 
-void *oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line);
-void oif_util_free_verbose(void *ptr, const char *file, const char *func, int line);
+void *
+oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line);
+void
+oif_util_free_verbose(void *ptr, const char *file, const char *func, int line);
 
 /**
  * Wrap `malloc` to collect debugging information about allocated memory.
@@ -27,11 +31,9 @@ void oif_util_free_verbose(void *ptr, const char *file, const char *func, int li
  * @param nbytes Number of bytes to allocate.
  * @return Pointer to the allocated memory.
  */
-#define oif_util_malloc(nbytes) \
-        oif_util_malloc_verbose((nbytes), __FILE__, __func__, __LINE__)
+#define oif_util_malloc(nbytes) oif_util_malloc_verbose((nbytes), __FILE__, __func__, __LINE__)
 
-#define oif_util_free(ptr) \
-        oif_util_free_verbose((ptr), __FILE__, __func__, __LINE__)
+#define oif_util_free(ptr) oif_util_free_verbose((ptr), __FILE__, __func__, __LINE__)
 
 /**
  * Convert `size_t` input to `uint32_t`.
@@ -57,8 +59,8 @@ oif_util_str_duplicate_(const char *src);
 char *
 oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line);
 
-#define oif_util_str_duplicate(src) \
-        oif_util_str_duplicate_verbose((src), __FILE__, __func__, __LINE__)
+#define oif_util_str_duplicate(src)                                     \
+    oif_util_str_duplicate_verbose((src), __FILE__, __func__, __LINE__)
 
 /**
  * Compare two C strings case-insensitively.

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -60,6 +61,16 @@ oif_util_str_duplicate(const char *src);
  */
 int
 oif_strcmp_nocase(const char *s1, const char *s2);
+
+/**
+ * Check if a string is contained in a null-trerminated array of strings.
+ *
+ * @param arr The null-terminated array of strings to search in.
+ * @param s The string to search for.
+ * @return true if the key is found, false otherwise.
+ */
+bool
+oif_util_str_contains(const char **arr, const char *s);
 
 /**
  * Log an error message to stderr.

--- a/include/oif/util.h
+++ b/include/oif/util.h
@@ -59,7 +59,7 @@ oif_util_str_duplicate(const char *src);
  * @return The same values as `string.h::strcmp`
  */
 int
-oif_strcmp_nocase(const char s1[static 1], const char s2[static 1]);
+oif_strcmp_nocase(const char *s1, const char *s2);
 
 /**
  * Log an error message to stderr.

--- a/lang_julia/OpenInterfaces/src/interfaces/ivp.jl
+++ b/lang_julia/OpenInterfaces/src/interfaces/ivp.jl
@@ -1,6 +1,6 @@
 module IVP
 
-using OpenInterfaces: ImplHandle, load_impl, call_impl, make_oif_callback, make_oif_user_data, OIF_FLOAT64, OIF_ARRAY_F64, OIF_INT, OIF_USER_DATA, OIFUserData
+using OpenInterfaces: ImplHandle, load_impl, call_impl, unload_impl, make_oif_callback, make_oif_user_data, OIF_FLOAT64, OIF_ARRAY_F64, OIF_INT, OIF_USER_DATA, OIFUserData
 
 export Self,
        set_initial_value,
@@ -20,8 +20,12 @@ mutable struct Self
     function Self(impl::String)
         implh = load_impl("ivp", impl, 1, 0)
         self = new(ImplHandle(implh), 0, Float64[], Nothing, Nothing)
-        f(t) = ccall(:jl_safe_printf, Cvoid, (Cstring, Cint), "Finalizing %d.\n", self.implh)
-        finalizer(f, self)
+        finalizer(finalizing, self)
+    end
+
+    function finalizing(self::Self)
+        """Finalization function to clean up resources."""
+        unload_impl(self.implh)
     end
 end
 

--- a/lang_julia/bridge_julia.c
+++ b/lang_julia/bridge_julia.c
@@ -57,6 +57,14 @@ handle_exception_(void)
     jl_exception_clear();
 }
 
+static void
+log_julia_variable_to_stderr(const char *varname, jl_value_t *var)
+{
+    fprintf(stderr, "%s = ", varname);
+    jl_static_show(JL_STDERR, var);
+    fprintf(stderr, "\n");
+}
+
 static int
 init_module_(void)
 {

--- a/lang_julia/bridge_julia.c
+++ b/lang_julia/bridge_julia.c
@@ -355,7 +355,7 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
         goto catch;
     }
 
-    result = malloc(sizeof *result);
+    result = oif_util_malloc(sizeof *result);
     if (result == NULL) {
         fprintf(stderr,
                 "[%s] Could not allocate memory for Julia implementation information\n",

--- a/lang_julia/bridge_julia.c
+++ b/lang_julia/bridge_julia.c
@@ -329,7 +329,7 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
         module_filename_full_p = module_filename_full;
         module_filename_full_p[0] = '\0';
     }
-    free(oif_impl_path_dup);
+    oif_util_free(oif_impl_path_dup);
 
     if (module_file == NULL) {
         fprintf(stderr, "[%s] Could not find an appropriate module file\n", prefix_);
@@ -383,11 +383,11 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
         fprintf(stderr, "[%s] Could not find function 'println' in Julia\n", prefix_);
         goto catch;
     }
-    printf("[%s] Instantiated self:\n", prefix_);
-    jl_call1(println_fn, self);
-    if (jl_exception_occurred()) {
-        goto catch;
-    }
+    // printf("[%s] Instantiated self:\n", prefix_);
+    // jl_call1(println_fn, self);
+    // if (jl_exception_occurred()) {
+    //     goto catch;
+    // }
 
     REFS_ = jl_eval_string("refs_ = IdDict()");
     if (jl_exception_occurred()) {

--- a/lang_python/oif_impl/CMakeLists.txt
+++ b/lang_python/oif_impl/CMakeLists.txt
@@ -10,6 +10,7 @@ target_include_directories(oif_bridge_python PRIVATE ${FFI_INCLUDE_DIRS})
 target_link_libraries(oif_bridge_python PUBLIC Python::Python)
 target_link_libraries(oif_bridge_python PUBLIC Python::NumPy)
 target_link_libraries(oif_bridge_python PRIVATE oif_common_data_structures)
+target_link_libraries(oif_bridge_python PRIVATE oif_common_util)
 install(TARGETS oif_bridge_python DESTINATION lib)
 
 add_library(oif_bridge_python_callback MODULE _callback.c)

--- a/lang_python/oif_impl/bridge_python.c
+++ b/lang_python/oif_impl/bridge_python.c
@@ -11,6 +11,7 @@
 
 #include <oif/api.h>
 #include <oif/config_dict.h>
+#include <oif/util.h>
 #include <oif/internal/bridge_api.h>
 
 typedef struct {
@@ -301,7 +302,7 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
     Py_DECREF(pInitArgs);
     Py_DECREF(pClass);
 
-    PythonImplInfo *impl_info = malloc(sizeof(*impl_info));
+    PythonImplInfo *impl_info = oif_util_malloc(sizeof(*impl_info));
     if (impl_info == NULL) {
         fprintf(stderr,
                 "[%s] Could not allocate memory for Python "

--- a/oif/lang_c/CMakeLists.txt
+++ b/oif/lang_c/CMakeLists.txt
@@ -8,5 +8,5 @@ target_include_directories(oif_c PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(oif_c
                            PUBLIC ${CMAKE_SOURCE_DIR}/oif/interfaces/c/include/)
 target_link_libraries(oif_c PUBLIC oif_common_data_structures)
-target_link_libraries(oif_c PRIVATE oif_common_util)
+target_link_libraries(oif_c PUBLIC oif_common_util)
 target_link_libraries(oif_c PRIVATE oif_dispatch)

--- a/oif/lang_c/c_bindings.c
+++ b/oif/lang_c/c_bindings.c
@@ -39,7 +39,7 @@ oif_create_array_f64(int nd, intptr_t *dimensions)
     for (size_t i = 0; i < nd; ++i) {
         size *= dimensions[i];
     }
-    x->data = (double *) oif_util_malloc(size * sizeof(double));
+    x->data = (double *)oif_util_malloc(size * sizeof(double));
 
     return x;
 }

--- a/oif/lang_c/c_bindings.c
+++ b/oif/lang_c/c_bindings.c
@@ -7,6 +7,8 @@
 #include <oif/api.h>
 #include <oif/c_bindings.h>
 
+#include <oif/util.h>
+
 #include <oif/internal/dispatch.h>
 
 ImplHandle
@@ -24,7 +26,7 @@ oif_unload_impl(ImplHandle implh)
 OIFArrayF64 *
 oif_create_array_f64(int nd, intptr_t *dimensions)
 {
-    OIFArrayF64 *x = malloc(sizeof(OIFArrayF64));
+    OIFArrayF64 *x = oif_util_malloc(sizeof(OIFArrayF64));
     x->nd = nd;
     x->dimensions = dimensions;
     x->flags = OIF_ARRAY_C_CONTIGUOUS;
@@ -37,7 +39,7 @@ oif_create_array_f64(int nd, intptr_t *dimensions)
     for (size_t i = 0; i < nd; ++i) {
         size *= dimensions[i];
     }
-    x->data = (double *)malloc(size * sizeof(double));
+    x->data = (double *) oif_util_malloc(size * sizeof(double));
 
     return x;
 }
@@ -67,8 +69,9 @@ oif_free_array_f64(OIFArrayF64 *x)
         return;
     }
 
-    free(x->data);
-    free(x);
+    oif_util_free(x->data);
+    oif_util_free(x);
+    x = NULL;
 }
 
 void

--- a/oif_impl/lang_c/allocation_tracker.c
+++ b/oif_impl/lang_c/allocation_tracker.c
@@ -2,6 +2,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "oif/util.h"
+
 #include "allocation_tracker.h"
 
 #define ALLOCATION_TRACKER_TYPE 120
@@ -19,17 +21,17 @@ struct allocation_tracker_t {
 AllocationTracker *
 allocation_tracker_init(void)
 {
-    AllocationTracker *tracker = malloc(sizeof(AllocationTracker));
+    AllocationTracker *tracker = oif_util_malloc(sizeof(AllocationTracker));
     if (tracker == NULL) {
         goto report_error_and_exit;
     }
 
     tracker->type = ALLOCATION_TRACKER_TYPE;
-    tracker->pointers = malloc(sizeof(*tracker->pointers) * INITIAL_CAPACITY_);
+    tracker->pointers = oif_util_malloc(sizeof(*tracker->pointers) * INITIAL_CAPACITY_);
     if (tracker->pointers == NULL) {
         goto report_error_and_exit;
     }
-    tracker->cleanup_fns = malloc(sizeof(*tracker->cleanup_fns) * INITIAL_CAPACITY_);
+    tracker->cleanup_fns = oif_util_malloc(sizeof(*tracker->cleanup_fns) * INITIAL_CAPACITY_);
     tracker->size = 0;
     tracker->capacity = INITIAL_CAPACITY_;
 
@@ -72,7 +74,8 @@ allocation_tracker_free(void *tracker_)
         tracker->cleanup_fns[i](tracker->pointers[i]);
     }
 
-    free(tracker->pointers);
-    free(tracker->cleanup_fns);
-    free(tracker);
+    oif_util_free(tracker->pointers);
+    oif_util_free(tracker->cleanup_fns);
+    oif_util_free(tracker);
+    tracker = NULL;
 }

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -39,9 +39,10 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
         return NULL;
     }
 
-    CImplInfo *impl_info = malloc(sizeof(CImplInfo));
+    CImplInfo *impl_info = oif_util_malloc(sizeof(CImplInfo));
     if (impl_info == NULL) {
         fprintf(stderr, "[%s] Could not create an implementation structure\n", prefix_);
+        dlclose(impl_lib);
         return NULL;
     }
     impl_info->impl_lib = impl_lib;

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -67,7 +67,12 @@ unload_impl(ImplInfo *impl_info_)
     }
     CImplInfo *impl_info = (CImplInfo *)impl_info_;
 
-    int status = dlclose(impl_info->impl_lib);
+    int status;
+#if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
+    status = dlclose(impl_info->impl_lib);
+#else
+    status = 0;
+#endif
     if (status != 0) {
         fprintf(stderr,
                 "[%s] While closing implementation '%s' an error occurred. "

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -19,7 +19,7 @@ typedef struct {
     char *impl_details;
 } CImplInfo;
 
-static int IMPL_COUNTER = 0;
+static int IMPL_COUNTER_ = 0;
 
 static char *prefix_ = "bridge_c";
 
@@ -51,6 +51,7 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
     fprintf(stderr, "[dispatch_c] load_impl impl_info->impl_details = %s\n",
             impl_info->impl_details);
 
+    IMPL_COUNTER_++;
     return (ImplInfo *)impl_info;
 }
 
@@ -73,7 +74,7 @@ unload_impl(ImplInfo *impl_info_)
                 "Error message: %s",
                 prefix_, impl_info->impl_details, dlerror());
     }
-    IMPL_COUNTER--;
+    IMPL_COUNTER_--;
 
     oif_util_free(impl_info->impl_details);
     return 0;

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -8,6 +8,7 @@
 #include <oif/api.h>
 #include <oif/config_dict.h>
 #include <oif/util.h>
+#include <oif/_platform.h>
 
 #include <oif/internal/bridge_api.h>
 
@@ -58,6 +59,7 @@ load_impl(const char *impl_details, size_t version_major, size_t version_minor)
 int
 unload_impl(ImplInfo *impl_info_)
 {
+    int status;
     if (impl_info_->dh != OIF_LANG_C) {
         fprintf(stderr,
                 "[%s] unload_impl received non-C implementation "
@@ -67,7 +69,41 @@ unload_impl(ImplInfo *impl_info_)
     }
     CImplInfo *impl_info = (CImplInfo *)impl_info_;
 
-    int status;
+    size_t free_fn_name_len = strlen("oif_") + strlen(impl_info_->interface) + strlen("_free") + 1;
+    char *free_fn_name = malloc(free_fn_name_len);
+    sprintf(free_fn_name, "%s%s%s", "oif_", impl_info_->interface, "_free");
+    void *free_fn = dlsym(impl_info->impl_lib, free_fn_name);
+
+    if (free_fn == NULL) {
+        logwarn(prefix_, "Implementation '%s' does not implement method '%s'\n", impl_info->impl_details, free_fn_name);
+    }
+    else {
+        OIFArgType in_arg_types[] = {OIF_USER_DATA};
+        void **in_arg_values = {NULL};
+        OIFArgs in_args = {
+            .num_args = 0,
+            .arg_types = in_arg_types,
+            .arg_values = in_arg_values,
+        };
+
+        OIFArgs out_args = {
+            .num_args = 0,
+            .arg_types = NULL,
+            .arg_values = NULL,
+        };
+
+        fprintf(stderr, "[%s] Calling method '%s' for implementation '%s'\n", prefix_,
+                free_fn_name, impl_info->impl_details);
+        status = call_impl(impl_info_, "oif_ivp_free", &in_args, &out_args);
+        if (status != 0) {
+            fprintf(stderr,
+                    "[%s] !!! Error occurred while calling method '%s' for "
+                    "implementation '%s'\n",
+                    prefix_, free_fn_name, impl_info->impl_details);
+        }
+    }
+    free(free_fn_name);
+
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
     status = dlclose(impl_info->impl_lib);
 #else

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -70,7 +70,7 @@ unload_impl(ImplInfo *impl_info_)
     int status = dlclose(impl_info->impl_lib);
     if (status != 0) {
         fprintf(stderr,
-                "[%] While closing implementation '%s' an error occurred. "
+                "[%s] While closing implementation '%s' an error occurred. "
                 "Error message: %s",
                 prefix_, impl_info->impl_details, dlerror());
     }

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -106,12 +106,12 @@ call_impl(ImplInfo *impl_info_, const char *method, OIFArgs *in_args, OIFArgs *o
     size_t num_out_args = out_args->num_args;
     unsigned int num_total_args = (unsigned int)(num_in_args + num_out_args);
 
-    arg_types = malloc(num_total_args * sizeof(ffi_type *));
+    arg_types = oif_util_malloc(num_total_args * sizeof(ffi_type *));
     if (arg_types == NULL) {
         fprintf(stderr, "[%s] Could not allocate memory for FFI types\n", prefix_);
         goto cleanup;
     }
-    arg_values = malloc(num_total_args * sizeof(void *));
+    arg_values = oif_util_malloc(num_total_args * sizeof(void *));
     if (arg_values == NULL) {
         fprintf(stderr, "[%s] Could not allocate memory for FFI values\n", prefix_);
         goto cleanup;
@@ -226,10 +226,10 @@ call_impl(ImplInfo *impl_info_, const char *method, OIFArgs *in_args, OIFArgs *o
 
 cleanup:
     if (arg_values != NULL) {
-        free(arg_values);
+        oif_util_free(arg_values);
     }
     if (arg_types != NULL) {
-        free(arg_types);
+        oif_util_free(arg_types);
     }
 
     if (tracker != NULL) {

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -69,13 +69,15 @@ unload_impl(ImplInfo *impl_info_)
     }
     CImplInfo *impl_info = (CImplInfo *)impl_info_;
 
-    size_t free_fn_name_len = strlen("oif_") + strlen(impl_info_->interface) + strlen("_free") + 1;
+    size_t free_fn_name_len =
+        strlen("oif_") + strlen(impl_info_->interface) + strlen("_free") + 1;
     char *free_fn_name = malloc(free_fn_name_len);
     sprintf(free_fn_name, "%s%s%s", "oif_", impl_info_->interface, "_free");
     void *free_fn = dlsym(impl_info->impl_lib, free_fn_name);
 
     if (free_fn == NULL) {
-        logwarn(prefix_, "Implementation '%s' does not implement method '%s'\n", impl_info->impl_details, free_fn_name);
+        logwarn(prefix_, "Implementation '%s' does not implement method '%s'\n",
+                impl_info->impl_details, free_fn_name);
     }
     else {
         OIFArgType in_arg_types[] = {OIF_USER_DATA};

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -74,7 +74,7 @@ unload_impl(ImplInfo *impl_info_)
     }
     IMPL_COUNTER--;
 
-    free(impl_info->impl_details);
+    oif_util_free(impl_info->impl_details);
     return 0;
 }
 

--- a/oif_impl/lang_c/bridge_c.c
+++ b/oif_impl/lang_c/bridge_c.c
@@ -97,7 +97,7 @@ call_impl(ImplInfo *impl_info_, const char *method, OIFArgs *in_args, OIFArgs *o
     void *service_lib = impl_info->impl_lib;
     void *func = dlsym(service_lib, method);
     if (func == NULL) {
-        fprintf(stderr, "[%s] Cannot load interface '%s'\n", prefix_, method);
+        fprintf(stderr, "[%s] Cannot load method '%s'\n", prefix_, method);
         fprintf(stderr, "[%s] dlerror() = %s\n", prefix_, dlerror());
         goto cleanup;
     }

--- a/oif_impl/oif/_impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/oif/_impl/ivp/sundials_cvode/sundials_cvode.c
@@ -74,7 +74,7 @@ static int
 init_(void)
 {
     int status;
-    
+
     // Clean up existing resources before reinitializing
     if (cvode_mem != NULL) {
         CVodeFree(&cvode_mem);
@@ -105,7 +105,8 @@ init_(void)
     // 8. Create matrix object
     /* A = SUNDenseMatrix(N, N, sunctx); */
     /* if (A == NULL) { */
-    /*     fprintf(stderr, "[sundials_cvode] Could not create matrix for dense linear solver\n"); */
+    /*     fprintf(stderr, "[sundials_cvode] Could not create matrix for dense linear
+     * solver\n"); */
     /*     return 2; */
     /* } */
 
@@ -172,7 +173,7 @@ init_(void)
         fprintf(stderr, "%s Could not create Fixed Point Nonlinear solver\n", prefix);
         return 7;
     }
-    
+
     // 14. Attach nonlinear solver module (optional)
     status = CVodeSetNonlinearSolver(cvode_mem, NLS);
     if (status != CV_SUCCESS) {
@@ -231,13 +232,13 @@ set_initial_value(OIFArrayF64 *y0_in, double t0_in)
     if (self_y0 != NULL) {
         N_VDestroy(self_y0);
     }
-    
+
     self_y0 = N_VMake_Serial(N, y0_in->data, sunctx);  // Problem vector.
     if (self_y0 == NULL) {
         fprintf(stderr, "%s Could not create initial value vector\n", prefix);
         return 3;
     }
-    
+
     // Sanity check that `sunrealtype` is actually the same as OIF_FLOAT64.
     assert(NV_Ith_S(self_y0, 0) == y0_in->data[0]);
 
@@ -307,7 +308,7 @@ set_integrator(const char *integrator_name, OIFConfigDict *config_)
     if (config != NULL) {
         oif_config_dict_free(config);
     }
-    
+
     config = config_;
     if (config != NULL) {
         const char **keys = oif_config_dict_get_keys(config);
@@ -377,7 +378,8 @@ integrate(double t, OIFArrayF64 *y)
         case CV_SUCCESS:
             return 0;
         default:
-            fprintf(stderr, "%s During call to `CVode`, an error occurred (code: %d)\n", prefix, ier);
+            fprintf(stderr, "%s During call to `CVode`, an error occurred (code: %d)\n",
+                    prefix, ier);
             return 1;
     }
 }
@@ -409,7 +411,7 @@ oif_ivp_free(void *self)
 {
     fprintf(stderr, "%s Freeing resources\n", prefix);
     (void)self;  // Fixed: cast to void to suppress unused parameter warning
-    
+
     if (self_y0 != NULL) {
         N_VDestroy(self_y0);
         self_y0 = NULL;
@@ -434,4 +436,6 @@ oif_ivp_free(void *self)
         oif_config_dict_free(config);
         config = NULL;
     }
+
+    return 0;
 }

--- a/oif_impl/oif/_impl/ivp/sundials_cvode/sundials_cvode.c
+++ b/oif_impl/oif/_impl/ivp/sundials_cvode/sundials_cvode.c
@@ -404,7 +404,7 @@ cvode_rhs(sunrealtype t, N_Vector y, N_Vector ydot, void *user_data)
     return result;
 }
 
-void
+int
 oif_ivp_free(void *self)
 {
     fprintf(stderr, "%s Freeing resources\n", prefix);

--- a/tests/lang_c/test_config_dict.cpp
+++ b/tests/lang_c/test_config_dict.cpp
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include <gtest/gtest.h>
 
 #include <oif/api.h>

--- a/tests/lang_c/test_config_dict.cpp
+++ b/tests/lang_c/test_config_dict.cpp
@@ -115,8 +115,8 @@ TEST(OIFConfigDictTest, GetCopyOfKeys)
     oif_config_dict_add_double(dict, "double_option", 2.718);
 
     const char **keys = oif_config_dict_get_keys(dict);
-    ASSERT_EQ(keys[0], "int_option");
-    ASSERT_EQ(keys[1], "double_option");
+    ASSERT_EQ(oif_util_str_contains(keys, "int_option"), true);
+    ASSERT_EQ(oif_util_str_contains(keys, "double_option"), true);
     ASSERT_EQ(keys[2], nullptr);
 
     oif_util_free(keys);

--- a/tests/lang_c/test_config_dict.cpp
+++ b/tests/lang_c/test_config_dict.cpp
@@ -2,6 +2,7 @@
 
 #include <oif/api.h>
 #include <oif/config_dict.h>
+#include <oif/util.h>
 
 TEST(OIFConfigDictTest, SimpleCase)
 {
@@ -104,4 +105,20 @@ TEST(OIFConfigDictTest, SerializeDeserializeVeryLongStringCase)
 
     oif_config_dict_free(dict);
     oif_config_dict_free(new_dict);
+}
+
+TEST(OIFConfigDictTest, GetCopyOfKeys)
+{
+    OIFConfigDict *dict = oif_config_dict_init();
+
+    oif_config_dict_add_int(dict, "int_option", 42);
+    oif_config_dict_add_double(dict, "double_option", 2.718);
+
+    const char **keys = oif_config_dict_get_keys(dict);
+    ASSERT_EQ(keys[0], "int_option");
+    ASSERT_EQ(keys[1], "double_option");
+    ASSERT_EQ(keys[2], nullptr);
+
+    oif_util_free(keys);
+    oif_config_dict_free(dict);
 }

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -164,84 +164,6 @@ struct SolverIntegratorsCombination {
 struct ImplTimesIntegratorsFixture
     : public testing::TestWithParam<SolverIntegratorsCombination> {};
 
-class SundialsCVODEConfigDictTest : public testing::Test {
-   protected:
-    void SetUp() override
-    {
-        const char *impl = "sundials_cvode";
-        problem = new ScalarExpDecayProblem();
-        double t0 = 0.0;
-        intptr_t dims[] = {
-            problem->N,
-        };
-        y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
-        y = oif_create_array_f64(1, dims);
-        implh = oif_load_impl("ivp", impl, 1, 0);
-        EXPECT_GT(implh, 0);
-
-        int status;
-        status = oif_ivp_set_initial_value(implh, y0, t0);
-        EXPECT_EQ(status, 0);
-        status = oif_ivp_set_user_data(implh, problem);
-        EXPECT_EQ(status, 0);
-        status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
-        EXPECT_EQ(status, 0);
-    }
-
-    void TearDown() override
-    {
-        oif_free_array_f64(y0);
-        oif_free_array_f64(y);
-        oif_unload_impl(implh);
-        delete problem;
-    }
-
-    ImplHandle implh;
-    ODEProblem *problem;
-    double t1 = 0.1;
-    OIFArrayF64 *y0;
-    OIFArrayF64 *y;
-};
-
-class ScipyODEConfigDictTest : public testing::Test {
-   protected:
-    ScipyODEConfigDictTest()
-    {
-        const char *impl = "scipy_ode";
-        problem = new ScalarExpDecayProblem();
-        double t0 = 0.0;
-        intptr_t dims[] = {
-            problem->N,
-        };
-        y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
-        y = oif_create_array_f64(1, dims);
-        implh = oif_load_impl("ivp", impl, 1, 0);
-        EXPECT_GT(implh, 0);
-
-        int status;
-        status = oif_ivp_set_initial_value(implh, y0, t0);
-        EXPECT_EQ(status, 0);
-        status = oif_ivp_set_user_data(implh, problem);
-        EXPECT_EQ(status, 0);
-        status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
-        EXPECT_EQ(status, 0);
-    }
-
-    ~ScipyODEConfigDictTest()
-    {
-        oif_free_array_f64(y0);
-        oif_free_array_f64(y);
-        delete problem;
-        oif_unload_impl(implh);
-    }
-
-    ImplHandle implh;
-    ODEProblem *problem;
-    double t1 = 0.1;
-    OIFArrayF64 *y0;
-    OIFArrayF64 *y;
-};
-
 INSTANTIATE_TEST_SUITE_P(
     IvpImplementationsTests, IvpImplementationsTimesODEProblemsFixture,
     testing::Combine(testing::Values("sundials_cvode"
@@ -340,6 +262,46 @@ TEST_P(ImplTimesIntegratorsFixture, SetIntegratorMethodWorks)
     delete problem;
 }
 
+// ----------------------------------------------------------------------------
+class SundialsCVODEConfigDictTest : public testing::Test {
+   protected:
+    void SetUp() override
+    {
+        const char *impl = "sundials_cvode";
+        problem = new ScalarExpDecayProblem();
+        double t0 = 0.0;
+        intptr_t dims[] = {
+            problem->N,
+        };
+        y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
+        y = oif_create_array_f64(1, dims);
+        implh = oif_load_impl("ivp", impl, 1, 0);
+        EXPECT_GT(implh, 0);
+
+        int status;
+        status = oif_ivp_set_initial_value(implh, y0, t0);
+        EXPECT_EQ(status, 0);
+        status = oif_ivp_set_user_data(implh, problem);
+        EXPECT_EQ(status, 0);
+        status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
+        EXPECT_EQ(status, 0);
+    }
+
+    void TearDown() override
+    {
+        oif_free_array_f64(y0);
+        oif_free_array_f64(y);
+        oif_unload_impl(implh);
+        delete problem;
+    }
+
+    ImplHandle implh;
+    ODEProblem *problem;
+    double t1 = 0.1;
+    OIFArrayF64 *y0;
+    OIFArrayF64 *y;
+};
+
 TEST_F(SundialsCVODEConfigDictTest, Test01)
 {
     OIFConfigDict *dict = oif_config_dict_init();
@@ -374,7 +336,48 @@ TEST_F(SundialsCVODEConfigDictTest, Test03)
     oif_config_dict_free(dict);
 }
 
+// ----------------------------------------------------------------------------
+
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
+class ScipyODEConfigDictTest : public testing::Test {
+   protected:
+    ScipyODEConfigDictTest()
+    {
+        const char *impl = "scipy_ode";
+        problem = new ScalarExpDecayProblem();
+        double t0 = 0.0;
+        intptr_t dims[] = {
+            problem->N,
+        };
+        y0 = oif_init_array_f64_from_data(1, dims, problem->y0);
+        y = oif_create_array_f64(1, dims);
+        implh = oif_load_impl("ivp", impl, 1, 0);
+        EXPECT_GT(implh, 0);
+
+        int status;
+        status = oif_ivp_set_initial_value(implh, y0, t0);
+        EXPECT_EQ(status, 0);
+        status = oif_ivp_set_user_data(implh, problem);
+        EXPECT_EQ(status, 0);
+        status = oif_ivp_set_rhs_fn(implh, ODEProblem::rhs_wrapper);
+        EXPECT_EQ(status, 0);
+    }
+
+    ~ScipyODEConfigDictTest()
+    {
+        oif_free_array_f64(y0);
+        oif_free_array_f64(y);
+        delete problem;
+        oif_unload_impl(implh);
+    }
+
+    ImplHandle implh;
+    ODEProblem *problem;
+    double t1 = 0.1;
+    OIFArrayF64 *y0;
+    OIFArrayF64 *y;
+};
+
 TEST_F(ScipyODEConfigDictTest, ShouldAcceptIntegratorParamsForDopri5)
 {
     OIFConfigDict *dict = oif_config_dict_init();

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -189,6 +189,7 @@ class SundialsCVODEConfigDictTest : public testing::Test {
     {
         oif_free_array_f64(y0);
         oif_free_array_f64(y);
+        oif_unload_impl(implh);
         delete problem;
     }
 
@@ -228,6 +229,7 @@ class ScipyODEConfigDictTest : public testing::Test {
         oif_free_array_f64(y0);
         oif_free_array_f64(y);
         delete problem;
+        oif_unload_impl(implh);
     }
 
     ImplHandle implh;

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -40,7 +40,7 @@ class ODEProblem {
         }
 
         this->N = other.N;
-        delete [] y0;
+        delete[] y0;
         this->y0 = new double[N];
         memcpy(y0, other.y0, sizeof(*y0) * this->N);
 
@@ -172,23 +172,20 @@ INSTANTIATE_TEST_SUITE_P(
                                      "scipy_ode", "jl_diffeq"
 #endif
                                      ),
-                     testing::Values(
-                         std::make_shared<ScalarExpDecayProblem>()
-                         ,
+                     testing::Values(std::make_shared<ScalarExpDecayProblem>(),
                                      std::make_shared<LinearOscillatorProblem>(),
-                                     std::make_shared<OrbitEquationsProblem>()
-    )));
+                                     std::make_shared<OrbitEquationsProblem>())));
 
-INSTANTIATE_TEST_SUITE_P(
-    IvpChangeIntegratorsTests, ImplTimesIntegratorsFixture,
-    testing::Values(SolverIntegratorsCombination{"sundials_cvode", {"bdf", "adams"}}
+INSTANTIATE_TEST_SUITE_P(IvpChangeIntegratorsTests, ImplTimesIntegratorsFixture,
+                         testing::Values(SolverIntegratorsCombination{"sundials_cvode",
+                                                                      {"bdf", "adams"}}
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
-                    // ,
-                    // SolverIntegratorsCombination{"scipy_ode",
-                    //                              {"vode", "lsoda", "dopri5", "dop853"}},
-                    // SolverIntegratorsCombination{"jl_diffeq", {"Tsit5"}}
+// ,
+// SolverIntegratorsCombination{"scipy_ode",
+//                              {"vode", "lsoda", "dopri5", "dop853"}},
+// SolverIntegratorsCombination{"jl_diffeq", {"Tsit5"}}
 #endif
-                    ));
+                                         ));
 
 // END fixtures
 // ----------------------------------------------------------------------------
@@ -265,7 +262,8 @@ TEST_P(ImplTimesIntegratorsFixture, SetIntegratorMethodWorks)
 // ----------------------------------------------------------------------------
 class SundialsCVODEConfigDictTest : public testing::Test {
    protected:
-    void SetUp() override
+    void
+    SetUp() override
     {
         const char *impl = "sundials_cvode";
         problem = new ScalarExpDecayProblem();
@@ -287,7 +285,8 @@ class SundialsCVODEConfigDictTest : public testing::Test {
         EXPECT_EQ(status, 0);
     }
 
-    void TearDown() override
+    void
+    TearDown() override
     {
         oif_free_array_f64(y0);
         oif_free_array_f64(y);

--- a/tests/lang_c/test_linsolve.cpp
+++ b/tests/lang_c/test_linsolve.cpp
@@ -3,7 +3,19 @@
 #include "oif/c_bindings.h"
 #include "oif/interfaces/linsolve.h"
 
+#include <oif/_platform.h>
+
 class LinearSolverFixture : public ::testing::TestWithParam<const char *> {};
+
+INSTANTIATE_TEST_SUITE_P(
+        LinearSolverTestSuite, LinearSolverFixture,
+        ::testing::Values(
+            "c_lapack"
+#if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
+            , "numpy", "jl_backslash"
+#endif
+    )
+);
 
 TEST_P(LinearSolverFixture, TestCase1)
 {
@@ -35,5 +47,3 @@ TEST_P(LinearSolverFixture, TestCase1)
     oif_unload_impl(implh);
 }
 
-INSTANTIATE_TEST_SUITE_P(LinearSolverTestSuite, LinearSolverFixture,
-                         ::testing::Values("c_lapack", "numpy", "jl_backslash"));

--- a/tests/lang_c/test_linsolve.cpp
+++ b/tests/lang_c/test_linsolve.cpp
@@ -7,15 +7,13 @@
 
 class LinearSolverFixture : public ::testing::TestWithParam<const char *> {};
 
-INSTANTIATE_TEST_SUITE_P(
-        LinearSolverTestSuite, LinearSolverFixture,
-        ::testing::Values(
-            "c_lapack"
+INSTANTIATE_TEST_SUITE_P(LinearSolverTestSuite, LinearSolverFixture,
+                         ::testing::Values("c_lapack"
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
-            , "numpy", "jl_backslash"
+                                           ,
+                                           "numpy", "jl_backslash"
 #endif
-    )
-);
+                                           ));
 
 TEST_P(LinearSolverFixture, TestCase1)
 {
@@ -46,4 +44,3 @@ TEST_P(LinearSolverFixture, TestCase1)
     oif_free_array_f64(roots);
     oif_unload_impl(implh);
 }
-

--- a/tests/lang_c/test_qeq.cpp
+++ b/tests/lang_c/test_qeq.cpp
@@ -32,9 +32,12 @@ INSTANTIATE_TEST_SUITE_P(
     QeqGatewayParameterizedTestSuite,
     QeqGatewayFixture,
     ::testing::Values(
-        "c_qeq_solver",
+        "c_qeq_solver"
+#if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
+        ,
         "jl_qeq_solver",
         "py_qeq_solver"
+#endif
     )
 );
 

--- a/tests/lang_c/test_qeq.cpp
+++ b/tests/lang_c/test_qeq.cpp
@@ -5,13 +5,14 @@
 
 #include <oif/_platform.h>
 
-
 class QeqGatewayFixture : public ::testing::TestWithParam<const char *> {
-protected:
+   protected:
     OIFArrayF64 *roots;
     ImplHandle implh;
 
-    void SetUp() override {
+    void
+    SetUp() override
+    {
         intptr_t dimensions[] = {
             2,
         };
@@ -22,26 +23,24 @@ protected:
         ASSERT_GT(implh, 0);
     }
 
-    void TearDown() override {
+    void
+    TearDown() override
+    {
         oif_free_array_f64(roots);
         oif_unload_impl(implh);
     }
 };
 
-INSTANTIATE_TEST_SUITE_P(
-    QeqGatewayParameterizedTestSuite,
-    QeqGatewayFixture,
-    ::testing::Values(
-        "c_qeq_solver"
+INSTANTIATE_TEST_SUITE_P(QeqGatewayParameterizedTestSuite, QeqGatewayFixture,
+                         ::testing::Values("c_qeq_solver"
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
-        ,
-        "jl_qeq_solver",
-        "py_qeq_solver"
+                                           ,
+                                           "jl_qeq_solver", "py_qeq_solver"
 #endif
-    )
-);
+                                           ));
 
-TEST_P(QeqGatewayFixture, LinearCase) {
+TEST_P(QeqGatewayFixture, LinearCase)
+{
     int status = oif_solve_qeq(implh, 0.0, 2.0, -1.0, roots);
     ASSERT_EQ(status, 0);
 

--- a/tests/lang_c/test_qeq.cpp
+++ b/tests/lang_c/test_qeq.cpp
@@ -3,173 +3,72 @@
 #include "oif/c_bindings.h"
 #include "oif/interfaces/qeq.h"
 
-TEST(QeqPyQeqSolverTestSuite, LinearCase)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "py_qeq_solver", 1, 0);
+#include <oif/_platform.h>
 
+
+class QeqGatewayFixture : public ::testing::TestWithParam<const char *> {
+protected:
+    OIFArrayF64 *roots;
+    ImplHandle implh;
+
+    void SetUp() override {
+        intptr_t dimensions[] = {
+            2,
+        };
+        roots = oif_create_array_f64(1, dimensions);
+        implh = oif_load_impl("qeq", GetParam(), 1, 0);
+
+        ASSERT_NE(roots, nullptr);
+        ASSERT_GT(implh, 0);
+    }
+
+    void TearDown() override {
+        oif_free_array_f64(roots);
+        oif_unload_impl(implh);
+    }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    QeqGatewayParameterizedTestSuite,
+    QeqGatewayFixture,
+    ::testing::Values(
+        "c_qeq_solver",
+        "jl_qeq_solver",
+        "py_qeq_solver"
+    )
+);
+
+TEST_P(QeqGatewayFixture, LinearCase) {
     int status = oif_solve_qeq(implh, 0.0, 2.0, -1.0, roots);
     ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], 0.5);
     EXPECT_EQ(roots->data[1], 0.5);
-
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
 }
 
-TEST(QeqPyQeqSolverTestSuite, TwoRoots)
+TEST_P(QeqGatewayFixture, TwoEqualRoots)
 {
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "py_qeq_solver", 1, 0);
-
     int status = oif_solve_qeq(implh, 1.0, 2.0, 1.0, roots);
     ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -1.0);
     EXPECT_EQ(roots->data[1], -1.0);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
 }
 
-TEST(QeqPyQeqSolverTestSuite, TwoDistinctRoots)
+TEST_P(QeqGatewayFixture, TwoDistinctRoots)
 {
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "py_qeq_solver", 1, 0);
-
     int status = oif_solve_qeq(implh, 1, 5, -14, roots);
     ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], -7);
     EXPECT_EQ(roots->data[1], +2);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
 }
 
-TEST(QeqCQeqSolverTestSuite, LinearCase)
+TEST_P(QeqGatewayFixture, ExtremeRoots)
 {
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "c_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 0.0, 2.0, -1.0, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], 0.5);
-    EXPECT_EQ(roots->data[1], 0.5);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqCQeqSolverTestSuite, TwoRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "c_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 1.0, 2.0, 1.0, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], -1.0);
-    EXPECT_EQ(roots->data[1], -1.0);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqCQeqSolverTestSuite, TwoDistinctRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "c_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 1, 5, -14, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], -7);
-    EXPECT_EQ(roots->data[1], +2);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqCQeqSolverTestSuite, ExtremeRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "c_qeq_solver", 1, 0);
-
     int status = oif_solve_qeq(implh, 1, -20'000, 1.0, roots);
     ASSERT_EQ(status, 0);
 
     EXPECT_EQ(roots->data[0], 19999.999949999998);
     EXPECT_EQ(roots->data[1], 5.000000012500001e-05);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqJlQeqSolverTestSuite, TwoRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "jl_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 1.0, 2.0, 1.0, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], -1.0);
-    EXPECT_EQ(roots->data[1], -1.0);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqJlQeqSolverTestSuite, TwoDistinctRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "jl_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 1, 5, -14, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], -7);
-    EXPECT_EQ(roots->data[1], +2);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
-}
-
-TEST(QeqJlQeqSolverTestSuite, ExtremeRoots)
-{
-    intptr_t dimensions[] = {
-        2,
-    };
-    OIFArrayF64 *roots = oif_create_array_f64(1, dimensions);
-    ImplHandle implh = oif_load_impl("qeq", "jl_qeq_solver", 1, 0);
-
-    int status = oif_solve_qeq(implh, 1, -20'000, 1.0, roots);
-    ASSERT_EQ(status, 0);
-
-    EXPECT_EQ(roots->data[0], 19999.999949999998);
-    EXPECT_EQ(roots->data[1], 5.000000012500001e-05);
-    oif_free_array_f64(roots);
-    oif_unload_impl(implh);
 }


### PR DESCRIPTION
# MaRDI Pull Request

This PR was started simply to add destructors to C implementations, so that they can clean allocated memory. However, the actual work done here is larger in focus because much more memory issues were solved.

**Changes**:
- Track memory allocations and releases with a global counter `NALLOCS_` in `util.c` with new functions
  `oif_util_malloc_` and `oif_util_free_`
- In the debug mode, `liboif_util.so` fails in the destructor, if `NALLOCS_ != 0`
- Add functions `oif_util_malloc_verbose`, `oif_util_free_verbose` to print verbose debug information
- Add macros `oif_util_malloc`, `oif_util_free` that actually inject debug information (file/function name, line number)
- Replace function `oif_util_str_duplicate` with the corresponding macro that injects debug information
- Add `_verbose` and `_` (non-verbose) variants of the former `oif_util_str_duplicate`
- Fix multiple memory leaks in C tests found mostly using LeakSanitizer feature of GCC
- Run C tests against Python and Julia implementations only in the case of compilation without sanitizers (because they crash with DLLs such as `libjulia`)
- Add optional invocation of a function `oif_INTERFACE_free` (if it exists) so that C implementations can release allocated memory
-  Fix a bag with recreating the global references dictionary in Julia on each `load_impl` that sometimes led to segmentation fault due to an attempt to remove `self` variables for implementations when they were already garbage-collected