### PR TITLE
Add CMake options to build code with verbose debug information and sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ project(
   LANGUAGES C CXX
   VERSION 0.5.5)
 
+option(OIF_OPTION_VERBOSE_DEBUG_INFO
+       "Enable verbose debug info in Debug builds" OFF)
+
+option(OIF_OPTION_SANITIZE
+    "Enable sanitizers in Debug builds" OFF)
+
 # Enforce using `-std=c11`, without any extensions like `gnu11`.
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -12,6 +18,13 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   message("Disable optimizations for Debug build type")
   string(PREPEND CMAKE_C_FLAGS_DEBUG "-O0 ")
+  if(OIF_OPTION_VERBOSE_DEBUG_INFO)
+    add_compile_definitions(OIF_VERBOSE_DEBUG_INFO)
+  endif()
+  if(OIF_OPTION_SANITIZE)
+    add_compile_options(-fno-omit-frame-pointer -fsanitize=address)
+    add_link_options(-fno-omit-frame-pointer -fsanitize=address)
+  endif()
 endif()
 
 # Incorporate additions by X/Open 7, that includes POSIX 17 additions and allow

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ project(
 option(OIF_OPTION_VERBOSE_DEBUG_INFO
        "Enable verbose debug info in Debug builds" OFF)
 
-option(OIF_OPTION_SANITIZE
-    "Enable sanitizers in Debug builds" OFF)
+option(OIF_OPTION_SANITIZE "Enable sanitizers in Debug builds" OFF)
 
 # Enforce using `-std=c11`, without any extensions like `gnu11`.
 set(CMAKE_C_STANDARD 11)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,22 @@ pytest-valgrind :
 	PYTHONMALLOC=malloc valgrind --show-leak-kinds=definite --log-file=/tmp/valgrind-output \
 	python -m pytest -s -vv --valgrind --valgrind-log=/tmp/valgrind-output
 
+# Build C code with verbose debug information
+# and enable `-fanitize=address` to detect memory errors.
+.PHONY : debug-verbose-info-and-sanitize
+debug-verbose-info-and-sanitize :
+	cmake -S . -B build.debug_verbose_info_and_sanitize \
+		-G Ninja \
+		-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DOIF_OPTION_VERBOSE_DEBUG_INFO=ON \
+        -DOIF_OPTION_SANITIZE=ON \
+		&& \
+	cmake --build build.debug_verbose_info_and_sanitize && \
+	rm -f build && \
+	ln -sv build.debug_verbose_info_and_sanitize build
+
 .PHONY : release
 release :
 	cmake -S . -B build.release \
@@ -39,7 +55,7 @@ release :
 
 .PHONY : clean
 clean :
-	$(RM) -r build build.debug build.release
+	$(RM) -r build build.debug build.debug_verbose_info_and_sanitize build.release
 
 .PHONY : docs
 docs : | mk-docs-build-dir

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ package := openinterfaces
 .PHONY : all
 all :
 	cmake -S . -B build.debug \
-		-DCMAKE_VERBOSE_MAKEFILE:BOOL=TRUE \
+		-G Ninja \
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
 		&& \
@@ -28,6 +28,7 @@ pytest-valgrind :
 .PHONY : release
 release :
 	cmake -S . -B build.release \
+		-G Ninja \
 		-DCMAKE_VERBOSE_MAKEFILE:BOOL=FALSE \
 		-DCMAKE_BUILD_TYPE=Release \
 		-DCMAKE_EXPORT_COMPILE_COMMANDS=ON \

--- a/common/util.c
+++ b/common/util.c
@@ -40,7 +40,7 @@ oif_util_malloc_(size_t nbytes)
 void *
 oif_util_malloc_verbose(size_t nbytes, const char *file, const char *func, int line)
 {
-#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
+#if defined(OIF_OPTION_VERBOSE_DEBUG_INFO)
     fprintf(stderr,
             "\033[31m"
             "[oif_util_malloc]"
@@ -87,7 +87,7 @@ oif_util_free_(void *ptr)
 void
 oif_util_free_verbose(void *ptr, const char *file, const char *func, int line)
 {
-#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
+#if defined(OIF_OPTION_VERBOSE_DEBUG_INFO)
     fprintf(stderr,
             "\033[31m[oif_util_free]\033[0m Freeing memory\n"
             "                  File: %s\n"
@@ -134,7 +134,7 @@ oif_util_str_duplicate_(const char *src)
 char *
 oif_util_str_duplicate_verbose(const char *src, const char *file, const char *func, int line)
 {
-#if defined(OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO)
+#if defined(OIF_OPTION_VERBOSE_DEBUG_INFO)
     fprintf(stderr,
             "\033[31m"
             "[oif_util_str_duplicate]"

--- a/include/oif/_platform.h
+++ b/include/oif/_platform.h
@@ -22,7 +22,7 @@
 //     ...Function implementation...
 // }
 
-#if defined(__GNUC__) && !defined(__OPTIMIZE__)
+#if defined(OIF_OPTION_VERBOSE_DEBUG_INFO)
 #define OIF_FLAG_PRINT_DEBUG_VERBOSE_INFO
 #else
 #endif

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -153,7 +153,6 @@ class OrbitEquationsProblem : public ODEProblem {
 
 // END ODEProblem and its derived classes.
 
-
 // ----------------------------------------------------------------------------
 // BEGIN Tests that use combinations of implementations and ODE problems.
 
@@ -204,7 +203,6 @@ TEST_P(IvpImplementationsTimesODEProblemsFixture, BasicTestCase)
     oif_free_array_f64(y);
     oif_unload_impl(implh);
 }
-
 
 // ----------------------------------------------------------------------------
 // BEGIN Tests that implementations-integrators.
@@ -263,7 +261,6 @@ TEST_P(ImplTimesIntegratorsFixture, SetIntegratorMethodWorks)
     delete problem;
 }
 // END Tests that use combinations of implementations and ODE problems.
-
 
 // ----------------------------------------------------------------------------
 // BEGIN Tests for integrator parameters via config dicts for `sundials_cvode`.
@@ -344,7 +341,6 @@ TEST_F(SundialsCVODEConfigDictTest, Test03)
     oif_config_dict_free(dict);
 }
 // END Tests for integrator parameters via config dicts for `sundials_cvode`.
-
 
 // ----------------------------------------------------------------------------
 // BEGIN Tests for integrator parameters via config dicts for `scipy_ode`.

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -12,8 +12,6 @@
 
 using namespace std;
 
-const double EPS = 0.9;
-
 // ----------------------------------------------------------------------------
 // BEGIN ODEProblem and its derived classes.
 
@@ -303,11 +301,13 @@ class SundialsCVODEConfigDictTest : public testing::Test {
         delete problem;
     }
 
+    // NOLINTBEGIN
     ImplHandle implh;
     ODEProblem *problem;
     double t1 = 0.1;
     OIFArrayF64 *y0;
     OIFArrayF64 *y;
+    // NOLINTEND
 };
 
 TEST_F(SundialsCVODEConfigDictTest, Test01)
@@ -382,11 +382,13 @@ class ScipyODEConfigDictTest : public testing::Test {
         oif_unload_impl(implh);
     }
 
+    // NOLINTBEGIN
     ImplHandle implh;
     ODEProblem *problem;
     double t1 = 0.1;
     OIFArrayF64 *y0;
     OIFArrayF64 *y;
+    // NOLINTEND
 };
 
 TEST_F(ScipyODEConfigDictTest, ShouldAcceptIntegratorParamsForDopri5)


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Do not build code in Debug configuration with verbose debug information and sanitizers by default (as before),
  as it is inconvenient to see so much information on every run
- Add two options for CMake for verbose debug information and sanitizers
-  Add auxiliary Make target to build code with these two CMake options
- Update `util.c` memory-allocating functions to check for defined macro `OIF_VERBOSE_DEBUG_INFO`
  instead of just checking for debug build, when deciding if verbose information about the file/func/line
  where memory allocation occurs