### PR TITLE
Fix failing tests due to not processing exit status of external commands on macOS

### DIFF
--- a/tests/lang_c/test_examples.cpp
+++ b/tests/lang_c/test_examples.cpp
@@ -1,6 +1,6 @@
 #include <cstdlib>
 #include <string>
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || defined(__APPLE__)
 #include <sys/wait.h>
 #endif
 
@@ -25,7 +25,7 @@ TEST_P(CallQEQFromCParameterizedTestFixture, RunsSuccessfully)
     const std::string arg = GetParam();
     const std::string command = program + " " + arg;
     int status = std::system(command.c_str());
-#ifdef __unix__
+#if defined(__unix__) || defined(__unix) || defined(__APPLE__)
     status = WEXITSTATUS(status);
 #endif
     if (status != OIF_BRIDGE_NOT_AVAILABLE_ERROR && status != OIF_IMPL_NOT_AVAILABLE_ERROR) {


### PR DESCRIPTION
On macOS, `test_examples` C tests fail when some implementations are not available.

The reason: an `std::system` call requires processing of the returned exit status with `WEXITSTATUS` on POSIX systems. The preprocessor condition that I used before (`#ifdef __unix__`) is not enough for macOS (it requires also `#ifdef __APPLE__`). This PR fixes this problem.