### PR TITLE
[ci] Enable again caching Conda and Julia environments

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -35,29 +35,24 @@ jobs:
               id: get-date
               run: echo "date=$(/bin/date -u "+%Y%m%d")" >> "$GITHUB_OUTPUT"
 
-            # - name: Cache Conda env
-            #   uses: actions/cache@v4
-            #   env:
-            #       # Increase this value to reset cache
-            #       # if etc/example-environment.yml has not changed.
-            #       CACHE_NUMBER: 1
-            #   with:
-            #       path: ~/conda_pkgs_dir
-            #       key: ${{ runner.os }}-python-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment-linux.yaml') }}
-            #   id: cache
-
-#             - name: Update environment
-#               run: |
-#                   conda env update --file environment-linux.yaml --name test
-#               # if: steps.cache.outputs.cache-hit != 'true'
+            - name: Cache Conda env
+              uses: actions/cache@v4
+              env:
+                  # Increase this value to reset cache
+                  # if etc/example-environment.yml has not changed.
+                  CACHE_NUMBER: 2
+              with:
+                  path: ~/conda_pkgs_dir
+                  key: ${{ runner.os }}-python-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('environment-linux.yaml') }}
+              id: cache
 
             - name: Set up Julia
               uses: julia-actions/setup-julia@v2
               with:
                   version: ${{ matrix.julia-version }}
 
-            # - name: Cache Julia artifacts
-            #   uses: julia-actions/cache@v1
+            - name: Cache Julia artifacts
+              uses: julia-actions/cache@v3
 
             - name: Activate Julia environment
               run: |


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Enable caching steps in the QA job on GitHub Actions, which was turned on previously to debug misterious never-running jobs (that were due to the `main` branch policy in the repo settings)