### PR TITLE
[ci] Build code in Release mode instead of Debug mode

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -90,7 +90,7 @@ jobs:
 
             - name: Build
               run: |
-                  make debug
+                  make release
             - name: Run tests
               run: |
                   make test


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Do `make release` instead of `make debug` (that was enabled before to understand a segmentation fault)