### PR TITLE
Add `ivp::dopri5c` to the test suite

### DIFF
--- a/common/oif_config_dict.c
+++ b/common/oif_config_dict.c
@@ -31,6 +31,8 @@ static size_t SIZE_ = 65;
 #define MAX_KEY_LENGTH_ 1024
 #define BUF_SIZE_ 128
 
+static char prefix_[] = "oif_config_dict";
+
 static char *
 copy_key_(const char *key)
 {
@@ -280,6 +282,18 @@ oif_config_dict_print(OIFConfigDict *dict)
 void
 oif_config_dict_serialize(OIFConfigDict *dict)
 {
+    if (dict == NULL) {
+        logerr(prefix_, "Serialization is possible only for non-NULL dict");
+        exit(1);
+    }
+
+    // Probably, not the best solution, as multiple invocation of serialization
+    // should be possible, but I just want to rectify a memory leak for now.
+    if (dict->pc != NULL) {
+        logerr(prefix_, "Serialization was already done");
+        exit(1);
+    }
+
     cw_pack_context *pc = oif_util_malloc(sizeof(*pc));
     if (pc == NULL) {
         fprintf(stderr,
@@ -471,7 +485,8 @@ oif_config_dict_copy_serialization(OIFConfigDict *to, const OIFConfigDict *from)
     }
     memcpy(to->buffer, from->buffer, from->buffer_length);
     to->buffer_length = from->buffer_length;
-    to->buffer[to->buffer_length] = '\0';  // Ensure null-termination.
+    // We put nul-terminator to be able to print out the buffer as a string.
+    to->buffer[to->buffer_length] = '\0';
     return 0;
 }
 

--- a/lang_c/oif_impl/_impl/ivp/dopri5c/dopri5c.c
+++ b/lang_c/oif_impl/_impl/ivp/dopri5c/dopri5c.c
@@ -284,6 +284,7 @@ set_integrator(Self *self, const char *integrator_name, OIFConfigDict *config_)
     (void)self;  // Unused in this implementation.
     (void)integrator_name;
     (void)config_;
+    oif_config_dict_free(config_);
     fprintf(stderr, "[%s] Method `set_integrator` is not supported\n", prefix_);
     return 1;
 }

--- a/lang_c/oif_impl/_impl/ivp/dopri5c/dopri5c.c
+++ b/lang_c/oif_impl/_impl/ivp/dopri5c/dopri5c.c
@@ -96,6 +96,16 @@ double const ORDER_OF_ACC = 4;
 static void
 compute_initial_step_(Self *self)
 {
+    if (self->rhs_fn == NULL) {
+        logerr(prefix_, "Invoke `set_rhs_fn` first");
+        return;
+    }
+
+    if (self->y == NULL) {
+        logerr(prefix_, "Invoke `set_initial_value` first");
+        return;
+    }
+
     double h0;
     double h1;
 
@@ -264,6 +274,7 @@ set_tolerances(Self *self, double rtol, double atol)
     (void)self;  // Unused in this implementation.
     self->rtol = rtol;
     self->atol = atol;
+    compute_initial_step_(self);
     return 0;
 }
 

--- a/tests/lang_c/test_ivp.cpp
+++ b/tests/lang_c/test_ivp.cpp
@@ -278,7 +278,7 @@ struct IvpImplementationsFixture : public testing::TestWithParam<const char *> {
 };
 
 INSTANTIATE_TEST_SUITE_P(IvpImplementationsTests, IvpImplementationsFixture,
-                         testing::Values("sundials_cvode"
+                         testing::Values("sundials_cvode", "dopri5c"
 #if !defined(OIF_SANITIZE_ADDRESS_ENABLED)
                                          ,
                                          "scipy_ode", "jl_diffeq"

--- a/tests/lang_julia/test_ivp.jl
+++ b/tests/lang_julia/test_ivp.jl
@@ -121,7 +121,7 @@ function MildlyStiffODESystem()
 end
 
 
-POTENTIAL_IMPLEMENTATIONS = ["sundials_cvode", "jl_diffeq", "scipy_ode"]
+POTENTIAL_IMPLEMENTATIONS = ["sundials_cvode", "dopri5c", "jl_diffeq", "scipy_ode"]
 IMPLEMENTATIONS = []
 for impl in POTENTIAL_IMPLEMENTATIONS
     implh = load_impl("ivp", impl, 1, 0)
@@ -151,6 +151,9 @@ end
 if "scipy_ode" in IMPLEMENTATIONS
     INTEGRATORS["scipy_ode"] = ["vode", "lsoda", "dopri5", "dop853"]
 end
+if "dopri5c" in IMPLEMENTATIONS
+    INTEGRATORS["dopri5c"] = []
+end
 
 PROBLEMS = [ScalarExpDecayProblem(), LinearOscillatorProblem(), OrbitEquationsProblem()]
 
@@ -176,8 +179,12 @@ PROBLEMS = [ScalarExpDecayProblem(), LinearOscillatorProblem(), OrbitEquationsPr
     function fixture_impl_integrators_prob(test_func)
         for impl in IMPLEMENTATIONS
             integrators = INTEGRATORS[impl]
-            prob = OrbitEquationsProblem()
-            test_func(impl, integrators, prob)
+            if length(integrators) == 0
+                println("Implementation $(impl) does not support setting integrators")
+            else
+                prob = OrbitEquationsProblem()
+                test_func(impl, integrators, prob)
+            end
         end
     end
 

--- a/tests/lang_python/test_ivp.py
+++ b/tests/lang_python/test_ivp.py
@@ -7,7 +7,7 @@ import pytest
 from openinterfaces.interfaces.ivp import IVP
 from scipy import optimize
 
-POSSIBLE_IMPLEMENTATIONS = ["scipy_ode", "sundials_cvode", "jl_diffeq"]
+POSSIBLE_IMPLEMENTATIONS = ["scipy_ode", "dopri5c", "sundials_cvode", "jl_diffeq"]
 IMPLEMENTATION_LIST = []
 
 for impl in POSSIBLE_IMPLEMENTATIONS:


### PR DESCRIPTION
# MaRDI Pull Request

**Changes**:
- Fix a memory leak of `OIFConfigDict` in `ivp::dopri5c`, as the implementations own passed dict by convention
- Add the `ivp::dopri5c` implementation to the tests from Python (`test_ivp.py`)
- Add the `ivp::dopri5c` implementation to the tests from Julia (`test_ivp.jl`)